### PR TITLE
feat(tools): add no-bump option to release mode

### DIFF
--- a/tools/release/internal/ui/model.go
+++ b/tools/release/internal/ui/model.go
@@ -36,6 +36,7 @@ type Model struct {
 
 	// Modo
 	bumpOnlyMode bool // true = solo bump + commit + push branch, sin tags
+	noBump       bool // true = no bump adicional, solo crear tags de la versión actual
 
 	// Ejecución
 	executing     bool
@@ -258,6 +259,13 @@ func (m Model) updateOutOfSync(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) updateBumpSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// En modo release completo hay 4 opciones (0=actual, 1=patch, 2=minor, 3=major)
+	// En modo bump-only hay 3 opciones (0=patch, 1=minor, 2=major)
+	maxCursor := 2
+	if !m.bumpOnlyMode {
+		maxCursor = 3
+	}
+
 	if key, ok := msg.(tea.KeyMsg); ok {
 		switch key.String() {
 		case "up", "k":
@@ -265,29 +273,53 @@ func (m Model) updateBumpSelect(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.bumpCursor--
 			}
 		case "down", "j":
-			if m.bumpCursor < 2 {
+			if m.bumpCursor < maxCursor {
 				m.bumpCursor++
 			}
 		case "enter":
-			m.newVersion = m.versions.Current.Bump(version.BumpType(m.bumpCursor))
-			// actualizar labels de steps con versión concreta
+			// Resetear steps al estado inicial antes de aplicar flags
+			m.steps = initSteps()
+
+			if !m.bumpOnlyMode && m.bumpCursor == 0 {
+				// Opción "sin bump adicional" — release de la versión actual
+				m.noBump = true
+				m.newVersion = m.versions.Current
+				for i := range m.steps {
+					switch m.steps[i].Step {
+					case StepWritePackageJSON, StepWriteTauriConf, StepWriteCargoToml, StepGitAdd, StepGitCommit:
+						m.steps[i].Status = StepSkipped
+					}
+				}
+			} else {
+				m.noBump = false
+				// Mapear cursor a BumpType
+				var bt version.BumpType
+				if m.bumpOnlyMode {
+					bt = version.BumpType(m.bumpCursor) // 0=patch, 1=minor, 2=major
+				} else {
+					bt = version.BumpType(m.bumpCursor - 1) // 1=patch, 2=minor, 3=major
+				}
+				m.newVersion = m.versions.Current.Bump(bt)
+				if m.bumpOnlyMode {
+					for i := range m.steps {
+						switch m.steps[i].Step {
+						case StepGitTagT1, StepGitTagT2, StepGitPushT1, StepGitPushT2:
+							m.steps[i].Status = StepSkipped
+						}
+					}
+				}
+			}
+
+			// Actualizar labels con la versión concreta
 			t1 := m.newVersion.Tag("t1")
 			t2 := m.newVersion.Tag("t2")
 			m.steps[5].Label = fmt.Sprintf("git tag %s", t1)
 			m.steps[6].Label = fmt.Sprintf("git tag %s", t2)
 			m.steps[8].Label = fmt.Sprintf("git push origin %s", t1)
 			m.steps[9].Label = fmt.Sprintf("git push origin %s", t2)
-			// en bump-only: marcar pasos de tags como skipped
-			if m.bumpOnlyMode {
-				for i := range m.steps {
-					switch m.steps[i].Step {
-					case StepGitTagT1, StepGitTagT2, StepGitPushT1, StepGitPushT2:
-						m.steps[i].Status = StepSkipped
-					}
-				}
-			}
 			m.state = StateConfirm
 		case "esc", "q":
+			m.bumpCursor = 0
 			m.state = StateDashboard
 		}
 	}

--- a/tools/release/internal/ui/views.go
+++ b/tools/release/internal/ui/views.go
@@ -80,13 +80,25 @@ func viewOutOfSync(m Model) string {
 
 func viewBumpSelect(m Model) string {
 	current := m.versions.Current
-	options := []struct {
-		label, desc string
-		bump        version.BumpType
-	}{
-		{"patch", "bug fixes, hotfixes", version.BumpPatch},
-		{"minor", "features nuevas, no breaking", version.BumpMinor},
-		{"major", "breaking changes", version.BumpMajor},
+
+	type option struct {
+		label, ver, desc string
+	}
+
+	var options []option
+	if !m.bumpOnlyMode {
+		options = []option{
+			{"actual", current.String(), "release sin bump adicional"},
+			{"patch", current.Bump(version.BumpPatch).String(), "bug fixes, hotfixes"},
+			{"minor", current.Bump(version.BumpMinor).String(), "features nuevas, no breaking"},
+			{"major", current.Bump(version.BumpMajor).String(), "breaking changes"},
+		}
+	} else {
+		options = []option{
+			{"patch", current.Bump(version.BumpPatch).String(), "bug fixes, hotfixes"},
+			{"minor", current.Bump(version.BumpMinor).String(), "features nuevas, no breaking"},
+			{"major", current.Bump(version.BumpMajor).String(), "breaking changes"},
+		}
 	}
 
 	var b strings.Builder
@@ -95,15 +107,14 @@ func viewBumpSelect(m Model) string {
 	b.WriteString("  Seleccioná el tipo de bump:\n\n")
 
 	for i, opt := range options {
-		newVer := current.Bump(opt.bump)
 		cursor := "  "
 		line := ""
 		if i == m.bumpCursor {
 			cursor = StyleSelected.Render("> ")
-			line = StyleSelected.Render(fmt.Sprintf("[●] %-7s → %s", opt.label, newVer.String())) +
+			line = StyleSelected.Render(fmt.Sprintf("[●] %-7s → %s", opt.label, opt.ver)) +
 				"  " + StyleMuted.Render("("+opt.desc+")")
 		} else {
-			line = fmt.Sprintf("    [○] %-7s → %s", opt.label, newVer.String()) +
+			line = fmt.Sprintf("    [○] %-7s → %s", opt.label, opt.ver) +
 				"  " + StyleMuted.Render("("+opt.desc+")")
 		}
 		b.WriteString(cursor + line + "\n")
@@ -128,16 +139,19 @@ func viewConfirm(m Model) string {
 	}
 	b.WriteString("  " + strings.Repeat("─", 44) + "\n\n")
 
-	b.WriteString("  Archivos que se modificarán:\n")
-	b.WriteString(fmt.Sprintf("    package.json               %s → %s\n",
-		StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
-	b.WriteString(fmt.Sprintf("    src-tauri/tauri.conf.json  %s → %s\n",
-		StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
-	b.WriteString(fmt.Sprintf("    src-tauri/Cargo.toml       %s → %s\n",
-		StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
-
-	b.WriteString("\n  Commit:\n")
-	b.WriteString(fmt.Sprintf("    %s\n", StyleKey.Render(fmt.Sprintf("chore(release): bump version to %s", newVer.String()))))
+	if m.noBump {
+		b.WriteString("  " + StyleWarning.Render("Sin bump adicional — se usan los archivos tal como están.") + "\n")
+	} else {
+		b.WriteString("  Archivos que se modificarán:\n")
+		b.WriteString(fmt.Sprintf("    package.json               %s → %s\n",
+			StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
+		b.WriteString(fmt.Sprintf("    src-tauri/tauri.conf.json  %s → %s\n",
+			StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
+		b.WriteString(fmt.Sprintf("    src-tauri/Cargo.toml       %s → %s\n",
+			StyleMuted.Render(m.versions.Current.String()), StyleSuccess.Render(newVer.String())))
+		b.WriteString("\n  Commit:\n")
+		b.WriteString(fmt.Sprintf("    %s\n", StyleKey.Render(fmt.Sprintf("chore(release): bump version to %s", newVer.String()))))
+	}
 
 	if !m.bumpOnlyMode {
 		t1 := newVer.Tag("t1")


### PR DESCRIPTION
Allow releasing current version without additional bump. Useful after running bump-only [b] to then tag and push with [n].