### PR TITLE
fix(auth,validation): robust session init and schema fallback transfo…

### DIFF
--- a/src/lib/schemaTransformer.ts
+++ b/src/lib/schemaTransformer.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/**
+ * Recorre un schema Zod recursivamente y agrega `.catch(fallback)` en cada
+ * tipo primitivo. Esto previene que null/undefined del backend revienten
+ * componentes que esperan string, number o boolean.
+ *
+ * Casos cubiertos:
+ *   null  donde esperaba string  → "N/A"
+ *   null  donde esperaba number  → 0
+ *   null  donde esperaba boolean → false
+ *
+ * Los campos ya declarados como `.nullable()` o `.optional()` no se ven
+ * afectados — solo actúa cuando el parse FALLA.
+ */
+export function withFallbacks<T extends z.ZodTypeAny>(schema: T): T {
+    if (schema instanceof z.ZodString) {
+        return schema.catch("N/A") as unknown as T;
+    }
+
+    if (schema instanceof z.ZodNumber) {
+        return schema.catch(0) as unknown as T;
+    }
+
+    if (schema instanceof z.ZodBoolean) {
+        return schema.catch(false) as unknown as T;
+    }
+
+    if (schema instanceof z.ZodObject) {
+        const newShape: Record<string, z.ZodTypeAny> = {};
+        for (const [key, val] of Object.entries(
+            schema.shape as Record<string, z.ZodTypeAny>
+        )) {
+            newShape[key] = withFallbacks(val);
+        }
+        return z.object(newShape) as unknown as T;
+    }
+
+    if (schema instanceof z.ZodArray) {
+        return z.array(withFallbacks(schema.element)) as unknown as T;
+    }
+
+    if (schema instanceof z.ZodNullable) {
+        return z.nullable(withFallbacks(schema._def.innerType)) as unknown as T;
+    }
+
+    if (schema instanceof z.ZodOptional) {
+        return z.optional(withFallbacks(schema._def.innerType)) as unknown as T;
+    }
+
+    // ZodEffects (.transform, .refine), ZodUnion, ZodEnum, ZodLiteral, etc.
+    // — pasar sin modificar
+    return schema;
+}

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -1,5 +1,6 @@
 import type z from "zod";
 import { Logger } from "./logger";
+import { withFallbacks } from "./schemaTransformer";
 
 export class Validator {
     static validate<T>(
@@ -7,7 +8,8 @@ export class Validator {
         data: unknown,
         context?: string
     ): T {
-        const result = schema.safeParse(data);
+        const robustSchema = withFallbacks(schema as z.ZodTypeAny) as z.ZodSchema<T>;
+        const result = robustSchema.safeParse(data);
 
         if (!result.success) {
             const errorMessage = `Validation failed${context ? ` for ${context}` : ''}`;
@@ -17,7 +19,9 @@ export class Validator {
                 receivedData: data,
             }, 'VALIDATOR');
 
-            throw new Error(`Invalid server response${context ? ` for ${context}` : ''}`);
+            // Backend inconsistente — loguear y retornar datos sin parsear
+            // en lugar de reventar la UI con una pantalla de error
+            return data as T;
         }
 
         Logger.debug(

--- a/src/modules/transfers/schemas/transferGetSchema.ts
+++ b/src/modules/transfers/schemas/transferGetSchema.ts
@@ -118,8 +118,8 @@ const ProductoDetalleSchema = z.object({
     stock_minimo: z.string().nullable(),
     precio_venta: z.string(),
     precio_venta_alt: z.string(),
-    id_marca_vehiculo: z.number(),
-    marca_vehiculo: MarcaVehiculoSchema,
+    id_marca_vehiculo: z.number().nullable(),
+    marca_vehiculo: MarcaVehiculoSchema.nullable(),
 });
 
 export const TransferDetailGetByIdSchema = z.object({

--- a/src/navigation/Navigation.tsx
+++ b/src/navigation/Navigation.tsx
@@ -33,17 +33,32 @@ const Navigation = () => {
   const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
+    // Garantía de inicialización: espera que IndexedDB resuelva antes de leer estado
+    authSDK.ready.then(() => {
+      const state = authSDK.getState();
+      if (state.user) {
+        setAuthState({
+          user: state.user,
+          selectedBranch: localStorage.getItem(environment.branch_selected_key),
+        });
+      } else {
+        setAuthState({ user: null, selectedBranch: null });
+      }
+      setIsLoading(false);
+      setIsInitialized(true);
+    });
+
+    // Cambios subsiguientes (login, logout, expiración)
     const unsubscribe = authSDK.onAuthStateChanged((possible: AuthState) => {
-      setIsLoading(true);
       if (!possible.user) {
         // Limpiar todas las tabs cuando el usuario cierra sesión o la sesión expira
         closeAllTabs();
         setAuthState({ user: null, selectedBranch: null });
       } else {
-        setAuthState(() => ({
+        setAuthState({
           user: possible.user,
           selectedBranch: localStorage.getItem(environment.branch_selected_key),
-        }));
+        });
       }
       setIsLoading(false);
       setIsInitialized(true);


### PR DESCRIPTION
…rmer

- Navigation: await authSDK.ready before reading state to fix race condition where onAuthStateChanged fired before component mounted, causing infinite splash screen (1-in-20 session loss on reload)
- Validator: soft contract — log Zod errors but return data instead of throwing, preventing white screens on backend inconsistencies
- schemaTransformer: recursive withFallbacks() wraps primitives with .catch() so null strings become 'N/A', null numbers become 0, null booleans become false
- transferGetSchema: id_marca_vehiculo and marca_vehiculo marked nullable to match backend reality for products without vehicle brand