### PR TITLE
fix(caja): fix schema validation errors and React 19 inert warning

### DIFF
--- a/src/components/tabs/TabContent.tsx
+++ b/src/components/tabs/TabContent.tsx
@@ -49,7 +49,7 @@ const TabContentComponent: React.FC<TabContentProps> = ({
           display: isActive ? "block" : "none",
           opacity: isActive ? 1 : 0,
         }}
-        {...(!isActive && { inert: "" as any })}
+        inert={!isActive || undefined}
       >
         {children}
       </div>

--- a/src/modules/caja/schemas/cashMovement.schema.ts
+++ b/src/modules/caja/schemas/cashMovement.schema.ts
@@ -4,7 +4,24 @@ import z from "zod";
 export const CashMovementSchema = z.object({
     id: z.number().int(),
     tipo_movimiento: z.enum(['INGRESO', 'EGRESO']),
-    concepto: z.enum(['VENTA', 'COBRO_CUENTA', 'INGRESO_MANUAL', 'EGRESO_MANUAL', 'GASTO', 'GASTO_NO_DEDUCIBLE']),
+    concepto: z.enum([
+        // Ingresos
+        'VENTA_CONTADO',
+        'VENTA_RAPIDA',
+        'VENTA_LOCAL',
+        'VENTA_MULTIPLE',
+        'COBRANZA_CREDITO',
+        'ANTICIPO_COTIZACION',
+        'INGRESO_MANUAL',
+        'ANULACION_DEVOLUCION',
+        // Egresos
+        'GASTO_NO_DEDUCIBLE',
+        'RETIRO_EFECTIVO',
+        'DEVOLUCION_CLIENTE',
+        'VUELTO',
+        'ANULACION_VENTA',
+        'ANULACION_COBRANZA',
+    ]),
     concepto_label: z.string(),
     origen: z.enum(['AUTOMATICO', 'MANUAL']),
     forma_pago: z.enum(['EFECTIVO', 'TRANSFERENCIA', 'QR', 'TARJETA']),

--- a/src/modules/caja/schemas/cashSession.schema.ts
+++ b/src/modules/caja/schemas/cashSession.schema.ts
@@ -18,7 +18,7 @@ export const CashSessionSchema = z.object({
     estado_label: z.string(),
     sucursal: BranchRefSchema,
     usuario_apertura: UserRefSchema,
-    usuario_cierre: UserRefSchema.nullable(),
+    usuario_cierre: UserRefSchema.nullish().transform(v => v ?? null),
     fecha_apertura: z.string(),
     fecha_cierre: z.string().nullable(),
     monto_apertura: z.coerce.number(),

--- a/src/modules/caja/types/cashMovement.types.ts
+++ b/src/modules/caja/types/cashMovement.types.ts
@@ -1,4 +1,20 @@
-export type CashMovementConcept = 'VENTA' | 'COBRO_CUENTA' | 'INGRESO_MANUAL' | 'EGRESO_MANUAL' | 'GASTO' | 'GASTO_NO_DEDUCIBLE';
+export type CashMovementConcept =
+    // Ingresos
+    | 'VENTA_CONTADO'
+    | 'VENTA_RAPIDA'
+    | 'VENTA_LOCAL'
+    | 'VENTA_MULTIPLE'
+    | 'COBRANZA_CREDITO'
+    | 'ANTICIPO_COTIZACION'
+    | 'INGRESO_MANUAL'
+    | 'ANULACION_DEVOLUCION'
+    // Egresos
+    | 'GASTO_NO_DEDUCIBLE'
+    | 'RETIRO_EFECTIVO'
+    | 'DEVOLUCION_CLIENTE'
+    | 'VUELTO'
+    | 'ANULACION_VENTA'
+    | 'ANULACION_COBRANZA';
 
 export type PaymentType = 'EFECTIVO' | 'TRANSFERENCIA' | 'QR' | 'TARJETA';
 


### PR DESCRIPTION
- Replace incomplete concepto enum with all 14 values from backend CashMovementConcept enum
- Fix usuario_cierre as nullish to handle absent field on open sessions
- Replace inert="" hack with inert={true} for React 19 native boolean support