### PR TITLE
feat(caja): integrate cash movements for quotation advances and customer refunds

### DIFF
--- a/src/modules/quotations/components/quotationsSummary.tsx
+++ b/src/modules/quotations/components/quotationsSummary.tsx
@@ -10,6 +10,21 @@ import { formatCurrency } from "@/utils/formaters";
 import { Badge } from "@/components/atoms/badge";
 import { Controller, useFormContext } from "react-hook-form";
 import { Switch } from "@/components/atoms/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/atoms/select";
+
+const PAYMENT_TYPE_OPTIONS = [
+  { value: "EFECTIVO", label: "Efectivo" },
+  { value: "CHEQUE", label: "Cheque" },
+  { value: "TRASNF", label: "Transferencia" },
+  { value: "QR", label: "QR" },
+  { value: "QR-EFECT", label: "QR y Efectivo" },
+];
 
 type DiscountType = "amount" | "percentage";
 
@@ -46,7 +61,8 @@ const QuotationsSummary: React.FC<QuotationSummaryProps> = ({
   hasProducts = false,
   secondaryButtonText,
 }) => {
-  const { control } = useFormContext();
+  const { control, watch, setValue, getValues } = useFormContext();
+  const anticipo = watch("anticipo") ?? 0;
 
   const handleSecondaryAction = () => {
     clearCart?.();
@@ -71,7 +87,7 @@ const QuotationsSummary: React.FC<QuotationSummaryProps> = ({
     <Card className="border border-border shadow-none md:flex-shrink-0">
       <CardContent className="space-y-2 p-2 sm:p-3">
         <div className="grid grid-cols-2 md:grid-cols-5 gap-2 items-center">
-          <div>
+          <div className="space-y-1">
             <Label className="text-xs" htmlFor="anticipo">
               Anticipo
             </Label>
@@ -81,7 +97,12 @@ const QuotationsSummary: React.FC<QuotationSummaryProps> = ({
               render={({ field }) => (
                 <EditablePrice
                   value={field.value || 0}
-                  onSubmit={(value) => field.onChange(value as number)}
+                  onSubmit={(value) => {
+                    field.onChange(value as number);
+                    if ((value as number) > 0 && !getValues("forma_pago_anticipo")) {
+                      setValue("forma_pago_anticipo", PAYMENT_TYPE_OPTIONS[0].value);
+                    }
+                  }}
                   className="w-full"
                   buttonClassName="w-full"
                   numberProps={{ min: 0, step: 0.01 }}
@@ -89,6 +110,30 @@ const QuotationsSummary: React.FC<QuotationSummaryProps> = ({
                 />
               )}
             />
+            {anticipo > 0 && (
+              <Controller
+                name="forma_pago_anticipo"
+                control={control}
+                render={({ field }) => (
+                  <Select
+                    value={field.value ?? ""}
+                    onValueChange={(val) => field.onChange(val || null)}
+                    disabled={isReadOnly}
+                  >
+                    <SelectTrigger className="h-7 text-xs">
+                      <SelectValue placeholder="Forma de pago..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PAYMENT_TYPE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            )}
           </div>
 
           <div className="space-y-1">

--- a/src/modules/quotations/schemas/quotationCreate.schema.ts
+++ b/src/modules/quotations/schemas/quotationCreate.schema.ts
@@ -27,6 +27,7 @@ export const QuotationCreateSchema = z.object({
     vehiculo: z.string().nullable(),
     nro_motor: z.string().nullable(),
     anticipo: z.number().nonnegative().transform((val) => parseFloat(val.toFixed(5))).nullable(),
+    forma_pago_anticipo: z.enum(['EFECTIVO', 'CHEQUE', 'TRASNF', 'QR', 'QR-EFECT']).nullable(),
     pedido: z.boolean(),
     sucursal: z.number(),
     id_responsable: z.number(),

--- a/src/modules/quotations/screens/quotationCreateScreen.tsx
+++ b/src/modules/quotations/screens/quotationCreateScreen.tsx
@@ -120,6 +120,7 @@ const QuotationCreateScreen = () => {
       cliente_contacto: "",
       cliente_telefono: "",
       anticipo: 0,
+      forma_pago_anticipo: null,
       pedido: false,
     },
   });
@@ -310,6 +311,7 @@ const QuotationCreateScreen = () => {
         cliente_contacto: "",
         cliente_telefono: "",
         anticipo: 0,
+        forma_pago_anticipo: null,
         pedido: false,
       });
 

--- a/src/modules/quotations/screens/quotationEditScreen.tsx
+++ b/src/modules/quotations/screens/quotationEditScreen.tsx
@@ -211,6 +211,7 @@ const QuotationEditScreen = () => {
       cliente_contacto: "",
       cliente_telefono: "",
       anticipo: 0,
+      forma_pago_anticipo: null,
       pedido: false,
     },
   });
@@ -264,6 +265,7 @@ const QuotationEditScreen = () => {
       cliente_contacto: quotation.cliente_contacto ?? "",
       cliente_telefono: quotation.cliente_telefono ?? "",
       anticipo: quotation.anticipo ?? 0,
+      forma_pago_anticipo: null,
       pedido: quotation.es_pedido,
     };
     reset(resetData);

--- a/src/modules/returns/schemas/returnCreateSchema.ts
+++ b/src/modules/returns/schemas/returnCreateSchema.ts
@@ -17,5 +17,7 @@ export const ReturnCreateSchema = z.object({
     responsable: z.number(),
     comentarios: z.string().nullable(),
     sucursal: z.number(),
+    monto_dev: z.number().nonnegative().nullable(),
+    forma_pago_dev: z.enum(['EFECTIVO', 'CHEQUE', 'TRASNF', 'QR', 'QR-EFECT']).nullable(),
     detalles: z.array(ReturnDetailCreateSchema).min(1),
 });

--- a/src/modules/returns/screens/returnCreateScreen.tsx
+++ b/src/modules/returns/screens/returnCreateScreen.tsx
@@ -38,6 +38,7 @@ import { Textarea } from "@/components/atoms/textarea";
 import { Button } from "@/components/atoms/button";
 import ShortcutKey from "@/components/common/ShortcutKey";
 import { formatCurrency } from "@/utils/formaters";
+import { EditablePrice } from "@/modules/shoppingCart/components/editablePrice";
 import type { ReturnDetailTableRef } from "../components/returnDetailTable";
 import {
   useReturnDetails,
@@ -104,6 +105,8 @@ const ReturnCreateScreen = () => {
       comentarios: "",
       sucursal: Number(selectedBranchId) || 1,
       responsable: Number(user?._id) || undefined,
+      monto_dev: 0,
+      forma_pago_dev: null,
       detalles: [],
     },
   });
@@ -115,6 +118,7 @@ const ReturnCreateScreen = () => {
     handleSubmit,
     setValue,
     getValues,
+    watch,
     setError,
     clearErrors,
     formState: { errors },
@@ -197,6 +201,8 @@ const ReturnCreateScreen = () => {
       sucursal: currentValues.sucursal,
       responsable:
         returnResponsiblesData?.data?.[0]?.id || currentValues.responsable,
+      monto_dev: 0,
+      forma_pago_dev: null,
       detalles: canClearDetails ? [] : currentValues.detalles,
     });
 
@@ -687,6 +693,61 @@ const ReturnCreateScreen = () => {
 
                     <Card className="border border-border shadow-none pt-3">
                       <CardContent className="space-y-2">
+                        <div className="flex gap-3 items-end">
+                          <div className="space-y-1">
+                            <Label className="text-xs">Reintegro (Bs)</Label>
+                            <Controller
+                              name="monto_dev"
+                              control={control}
+                              render={({ field }) => (
+                                <EditablePrice
+                                  value={field.value || 0}
+                                  onSubmit={(value) => {
+                                    field.onChange(value as number);
+                                    if ((value as number) > 0 && !getValues("forma_pago_dev")) {
+                                      setValue("forma_pago_dev", "EFECTIVO");
+                                    }
+                                  }}
+                                  className="w-36"
+                                  buttonClassName="w-36"
+                                  numberProps={{ min: 0, step: 0.01 }}
+                                />
+                              )}
+                            />
+                          </div>
+                          {(watch("monto_dev") ?? 0) > 0 && (
+                            <div className="space-y-1">
+                              <Label className="text-xs">Forma de pago</Label>
+                              <Controller
+                                name="forma_pago_dev"
+                                control={control}
+                                render={({ field }) => (
+                                  <Select
+                                    value={field.value ?? ""}
+                                    onValueChange={(val) => field.onChange(val || null)}
+                                  >
+                                    <SelectTrigger className="w-40 h-8 text-xs">
+                                      <SelectValue placeholder="Forma de pago..." />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {[
+                                        { value: "EFECTIVO", label: "Efectivo" },
+                                        { value: "CHEQUE", label: "Cheque" },
+                                        { value: "TRASNF", label: "Transferencia" },
+                                        { value: "QR", label: "QR" },
+                                        { value: "QR-EFECT", label: "QR y Efectivo" },
+                                      ].map((opt) => (
+                                        <SelectItem key={opt.value} value={opt.value} className="text-xs">
+                                          {opt.label}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                )}
+                              />
+                            </div>
+                          )}
+                        </div>
                         <footer className="flex gap-2 items-center justify-between">
                           <span className="text-xs text-muted-foreground">
                             * Campos requeridos


### PR DESCRIPTION
## Summary
- Add `forma_pago_anticipo` field to quotation create/edit forms so advance payments register as cash movements
- Add `monto_dev` and `forma_pago_dev` fields to return create form so customer refunds register as cash egress movements
- Payment method select auto-defaults to Efectivo when amount > 0

## Changes
| File | Change |
|------|--------|
| `src/modules/quotations/schemas/quotationCreate.schema.ts` | Add `forma_pago_anticipo` enum field |
| `src/modules/quotations/components/quotationsSummary.tsx` | Add conditional payment method select next to anticipo input |
| `src/modules/quotations/screens/quotationCreateScreen.tsx` | Add field to defaultValues and reset |
| `src/modules/quotations/screens/quotationEditScreen.tsx` | Add field to defaultValues and loadFormData reset |
| `src/modules/returns/schemas/returnCreateSchema.ts` | Add `monto_dev` and `forma_pago_dev` fields |
| `src/modules/returns/screens/returnCreateScreen.tsx` | Add refund amount input and payment method select to footer |

## Test Plan
- [ ] Create quotation with anticipo > 0 and verify cash movement is registered
- [ ] Create return with monto_dev > 0 and verify cash egress movement is registered
- [ ] Verify payment method select defaults to Efectivo automatically
- [ ] Verify select disappears when amount returns to 0