### PR TITLE
feat: complete CxP filters, quotation-to-sale flow, and secondary win…

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "1.4.1"
+version = "1.4.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src/modules/caja/components/modals/CashExpenseModal.tsx
+++ b/src/modules/caja/components/modals/CashExpenseModal.tsx
@@ -90,11 +90,9 @@ export function CashExpenseModal({
           onClose();
         },
         onError: (error: any) => {
-          const validationMsg = error?.response?.data?.errors?.monto?.[0]
-            ?? error?.response?.data?.message;
           showErrorToast({
             title: "Error al registrar gasto",
-            description: validationMsg || "Ocurrió un error al registrar el gasto.",
+            description: error?.message || "Ocurrió un error al registrar el gasto.",
           });
         },
       }

--- a/src/modules/caja/components/modals/CashWithdrawalModal.tsx
+++ b/src/modules/caja/components/modals/CashWithdrawalModal.tsx
@@ -83,11 +83,9 @@ export function CashWithdrawalModal({
           onClose();
         },
         onError: (error: any) => {
-          const validationMsg = error?.response?.data?.errors?.monto?.[0]
-            ?? error?.response?.data?.message;
           showErrorToast({
             title: "Error al registrar retiro",
-            description: validationMsg || "Ocurrió un error al registrar el retiro.",
+            description: error?.message || "Ocurrió un error al registrar el retiro.",
           });
         },
       }

--- a/src/modules/caja/schemas/cashMovement.schema.ts
+++ b/src/modules/caja/schemas/cashMovement.schema.ts
@@ -31,6 +31,7 @@ export const CashMovementSchema = z.object({
         'ANULACION_GASTO',
         'ANULACION_RETIRO',
         'PAGO_PROVEEDOR',
+        'ANULACION_PAGO_PROVEEDOR',
     ]),
     concepto_label: z.string(),
     origen: z.enum(['AUTOMATICO', 'MANUAL']),
@@ -39,6 +40,7 @@ export const CashMovementSchema = z.object({
     monto: z.coerce.number(),
     referencia_tipo: z.string().nullable(),
     referencia_id: z.number().int().nullable(),
+    grupo_cobro: z.string().nullable().optional(),
     tipo_gasto: z.object({
         id: z.number().int(),
         nombre: z.string(),

--- a/src/modules/caja/types/cashMovement.types.ts
+++ b/src/modules/caja/types/cashMovement.types.ts
@@ -23,7 +23,9 @@ export type CashMovementConcept =
     | 'ANULACION_VUELTO'
     | 'ANULACION_COBRANZA'
     | 'ANULACION_GASTO'
-    | 'ANULACION_RETIRO';
+    | 'ANULACION_RETIRO'
+    | 'PAGO_PROVEEDOR'
+    | 'ANULACION_PAGO_PROVEEDOR';
 
 export type PaymentType = 'EFECTIVO' | 'CHEQUE' | 'TRASNF' | 'QR' | 'QR-EFECT';
 
@@ -44,6 +46,7 @@ export interface CashMovement {
     monto: number;
     referencia_tipo: string | null;
     referencia_id: number | null;
+    grupo_cobro: string | null;
     tipo_gasto: { id: number; nombre: string } | null;
     descripcion: string | null;
     fecha_reg: string;

--- a/src/modules/cxp/components/cxpList/CxPFilters.tsx
+++ b/src/modules/cxp/components/cxpList/CxPFilters.tsx
@@ -1,13 +1,29 @@
 import { Button } from "@/components/atoms/button";
 import { Input } from "@/components/atoms/input";
 import { Label } from "@/components/atoms/label";
-import { Search } from "lucide-react";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/atoms/select";
+import { useProviders } from "@/modules/purchases/hooks/useProviders";
+import { PAYMENT_TERM_TYPES } from "../../schemas/cxpFilters.schema";
 import type { CxPPaginatedFilters } from "../../hooks/queries/useCxPPaginated";
+import { Search, X } from "lucide-react";
+
+const FECHA_VENCIMIENTO_REGLAS = {
+    ">=": "Desde (≥)",
+    "<=": "Hasta (≤)",
+    "=": "Igual (=)",
+} as const;
 
 interface CxPFiltersProps {
     filters: CxPPaginatedFilters;
     onFilterChange: (key: keyof CxPPaginatedFilters, value: string | number | undefined) => void;
     onSearch: () => void;
+    onReset?: () => void;
     searchMode?: "realtime" | "manual";
 }
 
@@ -15,11 +31,80 @@ const CxPFilters: React.FC<CxPFiltersProps> = ({
     filters,
     onFilterChange,
     onSearch,
+    onReset,
     searchMode = "manual",
 }) => {
+    const { data: providers = [] } = useProviders();
+
     return (
         <div className="space-y-2">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                {/* Proveedor */}
+                <div className="space-y-0.5">
+                    <Label className="text-xs">Proveedor</Label>
+                    <Select
+                        value={filters.proveedor ? String(filters.proveedor) : "all"}
+                        onValueChange={(val) =>
+                            onFilterChange("proveedor", val === "all" ? undefined : Number(val))
+                        }
+                    >
+                        <SelectTrigger className="h-7 text-xs">
+                            <SelectValue placeholder="Todos" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">Todos</SelectItem>
+                            {providers.map((p) => (
+                                <SelectItem key={p.id} value={String(p.id)}>
+                                    {p.nombre}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Estado de pago */}
+                <div className="space-y-0.5">
+                    <Label className="text-xs">Estado</Label>
+                    <Select
+                        value={filters.estado_pago ?? "all"}
+                        onValueChange={(val) =>
+                            onFilterChange("estado_pago", val === "all" ? undefined : val)
+                        }
+                    >
+                        <SelectTrigger className="h-7 text-xs">
+                            <SelectValue placeholder="Todos" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">Todos</SelectItem>
+                            <SelectItem value="DEUDA">Con deuda</SelectItem>
+                            <SelectItem value="PAGADO">Pagado</SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Vencimiento */}
+                <div className="space-y-0.5">
+                    <Label className="text-xs">Vencimiento</Label>
+                    <Select
+                        value={filters.tipo_vencimiento ?? "all"}
+                        onValueChange={(val) =>
+                            onFilterChange("tipo_vencimiento", val === "all" ? undefined : val)
+                        }
+                    >
+                        <SelectTrigger className="h-7 text-xs">
+                            <SelectValue placeholder="Todos" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">Todos</SelectItem>
+                            {Object.entries(PAYMENT_TERM_TYPES).map(([value, label]) => (
+                                <SelectItem key={value} value={value}>
+                                    {label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
                 {/* Fecha Inicio */}
                 <div className="space-y-0.5">
                     <Label className="text-xs">Fecha Inicio</Label>
@@ -46,13 +131,61 @@ const CxPFilters: React.FC<CxPFiltersProps> = ({
                     />
                 </div>
 
-                {/* Botón Buscar */}
+                {/* Vence — operador */}
+                <div className="space-y-0.5">
+                    <Label className="text-xs">Vence (fecha exacta)</Label>
+                    <Select
+                        value={filters.fecha_vencimiento_regla ?? "all"}
+                        onValueChange={(val) => {
+                            onFilterChange("fecha_vencimiento_regla", val === "all" ? undefined : val);
+                            if (val === "all") onFilterChange("fecha_vencimiento", undefined);
+                        }}
+                    >
+                        <SelectTrigger className="h-7 text-xs">
+                            <SelectValue placeholder="Sin filtro" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="all">Sin filtro</SelectItem>
+                            {Object.entries(FECHA_VENCIMIENTO_REGLAS).map(([value, label]) => (
+                                <SelectItem key={value} value={value}>
+                                    {label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Vence — fecha */}
+                <div className="space-y-0.5">
+                    <Label className="text-xs">Fecha vencimiento</Label>
+                    <Input
+                        type="date"
+                        value={filters.fecha_vencimiento ?? ""}
+                        onChange={(e) =>
+                            onFilterChange("fecha_vencimiento", e.target.value || undefined)
+                        }
+                        disabled={!filters.fecha_vencimiento_regla}
+                        className="h-7 text-xs disabled:opacity-40"
+                    />
+                </div>
+
+                {/* Acciones */}
                 {searchMode === "manual" && (
-                    <div className="flex items-end">
-                        <Button onClick={onSearch} className="h-7 text-xs px-3">
+                    <div className="flex items-end gap-1">
+                        <Button onClick={onSearch} className="h-7 text-xs px-3 flex-1">
                             <Search className="size-3 mr-1" />
                             Buscar
                         </Button>
+                        {onReset && (
+                            <Button
+                                variant="outline"
+                                onClick={onReset}
+                                className="h-7 text-xs px-2"
+                                title="Limpiar filtros"
+                            >
+                                <X className="size-3" />
+                            </Button>
+                        )}
                     </div>
                 )}
             </div>

--- a/src/modules/cxp/hooks/queries/useCxPPaginated.ts
+++ b/src/modules/cxp/hooks/queries/useCxPPaginated.ts
@@ -11,6 +11,10 @@ export interface CxPPaginatedFilters
     fecha_fin?: string;
     pagina?: number;
     pagina_registros?: number;
+    estado_pago?: "PAGADO" | "DEUDA";
+    tipo_vencimiento?: string;
+    fecha_vencimiento_regla?: ">=" | "<=" | "=";
+    fecha_vencimiento?: string;
 }
 
 const useCxPPaginated = (filters: CxPPaginatedFilters = {}) => {
@@ -20,6 +24,8 @@ const useCxPPaginated = (filters: CxPPaginatedFilters = {}) => {
     const mergedFilters: Partial<CxPFilters> = {
         ...filters,
         sucursal,
+        ...(filters.tipo_vencimiento ? { condicion_vencimiento: true } : {}),
+        ...(filters.fecha_vencimiento ? { condicion_fecha_especifica: true } : {}),
     };
 
     return useQuery({

--- a/src/modules/cxp/schemas/cxpFilters.schema.ts
+++ b/src/modules/cxp/schemas/cxpFilters.schema.ts
@@ -1,10 +1,15 @@
 import { z } from "zod";
 
-/**
- * Schema para los filtros de la lista paginada de CxP
- *
- * GET /api/v1/account-payable?sucursal=X&proveedor=X&fecha_inicio=X&fecha_fin=X
- */
+export const PAYMENT_TERM_TYPES = {
+    "SIN PLAZO": "Pendiente",
+    "VENCIDO": "Vencido",
+    "POR VENCER EN 15 DIAS": "Por vencer en 15 días",
+    "POR VENCER EN 30 DIAS": "Por vencer en 30 días",
+    "POR VENCER EN 45 DIAS": "Por vencer en 45 días",
+} as const;
+
+export type PaymentTermType = keyof typeof PAYMENT_TERM_TYPES;
+
 export const CxPFiltersSchema = z.object({
     sucursal: z.number().int().optional(),
     proveedor: z.number().int().nullable().optional(),
@@ -12,6 +17,12 @@ export const CxPFiltersSchema = z.object({
     fecha_fin: z.string().optional(),
     pagina: z.number().int().positive().optional(),
     pagina_registros: z.number().int().positive().optional(),
+    estado_pago: z.enum(["PAGADO", "DEUDA"]).optional(),
+    condicion_vencimiento: z.boolean().optional(),
+    tipo_vencimiento: z.string().optional(),
+    condicion_fecha_especifica: z.boolean().optional(),
+    fecha_vencimiento_regla: z.enum([">=", "<=", "="]).optional(),
+    fecha_vencimiento: z.string().optional(),
 });
 
 export type CxPFilters = z.infer<typeof CxPFiltersSchema>;

--- a/src/modules/cxp/schemas/cxpReport.schema.ts
+++ b/src/modules/cxp/schemas/cxpReport.schema.ts
@@ -57,6 +57,9 @@ export const CxPGeneralReportFilterSchema = z.object({
   sucursal: z.number().int(),
   fecha_inicio: z.string().min(1, "La fecha de inicio es requerida"),
   fecha_fin: z.string().min(1, "La fecha de fin es requerida"),
+  proveedor: z.number().int().optional(),
+  fecha_plazo_inicio: z.string().optional(),
+  fecha_plazo_fin: z.string().optional(),
 });
 
 export const CxPGeneralReportResponseSchema = z.array(CxPReportItemSchema);
@@ -72,7 +75,7 @@ export type CxPGeneralReportResponse = z.infer<typeof CxPGeneralReportResponseSc
 
 export const CxPBySupplierReportFilterSchema = z.object({
   sucursal: z.number().int(),
-  proveedor: z.number().int(),
+  proveedor: z.number().int().optional(),
   fecha_inicio: z.string().optional(),
   fecha_fin: z.string().optional(),
 });
@@ -105,7 +108,18 @@ export type CxPProjectionReportResponse = z.infer<typeof CxPProjectionReportResp
 // ─────────────────────────────────────────────
 // Reporte Ranking de Proveedores CxP
 // POST /api/v1/accounts-payable/reports/supplier-ranking
+// Shape: array agregado por proveedor (una fila por proveedor)
 // ─────────────────────────────────────────────
+
+export const CxPRankingItemSchema = z.object({
+  proveedor_id: z.number().int(),
+  proveedor: z.string(),
+  nit: z.string().nullable(),
+  total_compras: z.coerce.number(),
+  volumen_compra: z.coerce.number(),
+  total_pagado: z.coerce.number(),
+  deuda_pendiente: z.coerce.number(),
+});
 
 export const CxPRankingReportFilterSchema = z.object({
   sucursal: z.number().int(),
@@ -113,9 +127,8 @@ export const CxPRankingReportFilterSchema = z.object({
   fecha_fin: z.string().optional(),
 });
 
-export const CxPRankingReportResponseSchema = z.object({
-  data: z.array(CxPListItemSchema),
-});
+export const CxPRankingReportResponseSchema = z.array(CxPRankingItemSchema);
 
+export type CxPRankingItem = z.infer<typeof CxPRankingItemSchema>;
 export type CxPRankingReportFilter = z.infer<typeof CxPRankingReportFilterSchema>;
 export type CxPRankingReportResponse = z.infer<typeof CxPRankingReportResponseSchema>;

--- a/src/modules/cxp/screens/CxPBySupplierReportScreen.tsx
+++ b/src/modules/cxp/screens/CxPBySupplierReportScreen.tsx
@@ -1,6 +1,13 @@
 import { Badge } from "@/components/atoms/badge";
 import { Button } from "@/components/atoms/button";
 import { Label } from "@/components/atoms/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/atoms/select";
 import VirtualizedCustomizableTable from "@/components/common/VirtualizedCustomizableTable";
 import TooltipButton from "@/components/common/TooltipButton";
 import { useCustomTable } from "@/hooks/useCustomTable";
@@ -12,13 +19,15 @@ import { subMonths, format } from "date-fns";
 import { formatCurrency } from "@/utils/formaters";
 import { parseDateForUi } from "@/utils/dateFormatters";
 import useCxPBySupplierReport, { useDownloadCxPBySupplierReport } from "../hooks/useCxPBySupplierReport";
-import type { CxPListItem, CxPBySupplierReportFilter } from "../schemas/cxpReport.schema";
+import type { CxPReportItem, CxPBySupplierReportFilter } from "../schemas/cxpReport.schema";
 import authSDK from "@/services/sdk-simple-auth";
 import { ComboboxSelect } from "@/components/common/SelectCombobox";
+import { useProviders } from "@/modules/purchases/hooks/useProviders";
 
 const CxPBySupplierReportScreen = () => {
     const selectedBranchId = useBranchStore((s) => s.selectedBranchId);
     const branches = authSDK.getCurrentUser()?.sucursales || [];
+    const { data: providers = [] } = useProviders();
 
     const [sucursal, setSucursal] = useState<number | null>(
         selectedBranchId ? Number(selectedBranchId) : null
@@ -27,6 +36,7 @@ const CxPBySupplierReportScreen = () => {
         format(subMonths(new Date(), 1), "yyyy-MM-dd")
     );
     const [fechaFin, setFechaFin] = useState<string>(format(new Date(), "yyyy-MM-dd"));
+    const [proveedor, setProveedor] = useState<number | null>(null);
 
     useEffect(() => {
         setSucursal(selectedBranchId ? Number(selectedBranchId) : null);
@@ -48,16 +58,16 @@ const CxPBySupplierReportScreen = () => {
 
     const { mutate: downloadReport, isPending: isDownloading } = useDownloadCxPBySupplierReport();
 
-    const data = reportData?.data ?? [];
+    const data = reportData ?? [];
 
     const stats = useMemo(() => {
-        const totalSaldo = data.reduce((sum, item) => sum + item.saldo_pendiente, 0);
-        const proveedoresUnicos = new Set(data.map((item) => item.proveedor.id)).size;
-        const cuentasPendientes = data.filter((item) => item.saldo_pendiente > 0).length;
+        const totalSaldo = data.reduce((sum, item) => sum + item.saldo, 0);
+        const proveedoresUnicos = new Set(data.map((item) => item.proveedor)).size;
+        const cuentasPendientes = data.filter((item) => item.saldo > 0).length;
         return { totalItems: data.length, totalSaldo, proveedoresUnicos, cuentasPendientes };
     }, [data]);
 
-    const columns = useMemo<ColumnDef<CxPListItem>[]>(
+    const columns = useMemo<ColumnDef<CxPReportItem>[]>(
         () => [
             {
                 id: "rowNumber",
@@ -73,8 +83,7 @@ const CxPBySupplierReportScreen = () => {
                 ),
             },
             {
-                id: "proveedor_nombre",
-                accessorFn: (row) => row.proveedor.nombre,
+                accessorKey: "proveedor",
                 header: "Proveedor",
                 size: 250,
                 minSize: 150,
@@ -83,7 +92,7 @@ const CxPBySupplierReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "nro_compra",
+                accessorKey: "nro",
                 header: "Nro. Compra",
                 size: 130,
                 minSize: 100,
@@ -92,7 +101,7 @@ const CxPBySupplierReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "fecha_in",
+                accessorKey: "fecha",
                 header: "Fecha",
                 size: 120,
                 minSize: 100,
@@ -111,7 +120,7 @@ const CxPBySupplierReportScreen = () => {
                 },
             },
             {
-                accessorKey: "total_compra",
+                accessorKey: "total",
                 header: "Total Compra",
                 size: 140,
                 minSize: 100,
@@ -124,7 +133,7 @@ const CxPBySupplierReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "total_pagado",
+                accessorKey: "pagos",
                 header: "Pagado",
                 size: 140,
                 minSize: 100,
@@ -137,7 +146,7 @@ const CxPBySupplierReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "saldo_pendiente",
+                accessorKey: "saldo",
                 header: "Saldo",
                 size: 140,
                 minSize: 100,
@@ -159,7 +168,7 @@ const CxPBySupplierReportScreen = () => {
         []
     );
 
-    const { table } = useCustomTable({
+    const { table } = useCustomTable<CxPReportItem>({
         data,
         columns,
         enableSorting: true,
@@ -178,6 +187,7 @@ const CxPBySupplierReportScreen = () => {
             sucursal,
             fecha_inicio: overrideFechaInicio ?? fechaInicio,
             fecha_fin: overrideFechaFin ?? fechaFin,
+            ...(proveedor ? { proveedor } : {}),
         });
     };
 
@@ -261,6 +271,26 @@ const CxPBySupplierReportScreen = () => {
                                 optionTag="sucursal"
                                 allowClear={false}
                             />
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            <Label className="text-sm whitespace-nowrap">Proveedor:</Label>
+                            <Select
+                                value={proveedor ? String(proveedor) : "all"}
+                                onValueChange={(val) => setProveedor(val === "all" ? null : Number(val))}
+                            >
+                                <SelectTrigger className="h-8 text-sm w-48">
+                                    <SelectValue placeholder="Todos" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="all">Todos</SelectItem>
+                                    {providers.map((p) => (
+                                        <SelectItem key={p.id} value={String(p.id)}>
+                                            {p.nombre}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
                         </div>
 
                         <Button variant="default" onClick={() => handleSearch()} disabled={isFetching || !sucursal}>

--- a/src/modules/cxp/screens/CxPGeneralReportScreen.tsx
+++ b/src/modules/cxp/screens/CxPGeneralReportScreen.tsx
@@ -1,6 +1,13 @@
 import { Badge } from "@/components/atoms/badge";
 import { Button } from "@/components/atoms/button";
 import { Label } from "@/components/atoms/label";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/atoms/select";
 import VirtualizedCustomizableTable from "@/components/common/VirtualizedCustomizableTable";
 import TooltipButton from "@/components/common/TooltipButton";
 import { useCustomTable } from "@/hooks/useCustomTable";
@@ -15,10 +22,12 @@ import useCxPGeneralReport, { useDownloadCxPGeneralReport } from "../hooks/useCx
 import type { CxPReportItem, CxPGeneralReportFilter } from "../schemas/cxpReport.schema";
 import authSDK from "@/services/sdk-simple-auth";
 import { ComboboxSelect } from "@/components/common/SelectCombobox";
+import { useProviders } from "@/modules/purchases/hooks/useProviders";
 
 const CxPGeneralReportScreen = () => {
     const selectedBranchId = useBranchStore((s) => s.selectedBranchId);
     const branches = authSDK.getCurrentUser()?.sucursales || [];
+    const { data: providers = [] } = useProviders();
 
     const [sucursal, setSucursal] = useState<number | null>(
         selectedBranchId ? Number(selectedBranchId) : null
@@ -27,6 +36,9 @@ const CxPGeneralReportScreen = () => {
         format(subMonths(new Date(), 1), "yyyy-MM-dd")
     );
     const [fechaFin, setFechaFin] = useState<string>(format(new Date(), "yyyy-MM-dd"));
+    const [proveedor, setProveedor] = useState<number | null>(null);
+    const [fechaPlazoInicio, setFechaPlazoInicio] = useState<string>("");
+    const [fechaPlazoFin, setFechaPlazoFin] = useState<string>("");
 
     useEffect(() => {
         setSucursal(selectedBranchId ? Number(selectedBranchId) : null);
@@ -171,6 +183,9 @@ const CxPGeneralReportScreen = () => {
             sucursal,
             fecha_inicio: overrideFechaInicio ?? fechaInicio,
             fecha_fin: overrideFechaFin ?? fechaFin,
+            ...(proveedor ? { proveedor } : {}),
+            ...(fechaPlazoInicio ? { fecha_plazo_inicio: fechaPlazoInicio } : {}),
+            ...(fechaPlazoFin ? { fecha_plazo_fin: fechaPlazoFin } : {}),
         });
     };
 
@@ -232,7 +247,7 @@ const CxPGeneralReportScreen = () => {
                         </Button>
                     </div>
 
-                    {/* Controles */}
+                    {/* Controles — fila 1: fechas de compra + sucursal */}
                     <div className="flex items-center gap-4 flex-wrap">
                         <div className="flex items-center gap-2">
                             <Label htmlFor="cxp-gr-inicio" className="text-sm">Desde:</Label>
@@ -267,6 +282,51 @@ const CxPGeneralReportScreen = () => {
                                 enableAllOption={true}
                                 optionTag="sucursal"
                                 allowClear={false}
+                            />
+                        </div>
+                    </div>
+
+                    {/* Controles — fila 2: proveedor + fechas de vencimiento de plazo */}
+                    <div className="flex items-center gap-4 flex-wrap">
+                        <div className="flex items-center gap-2">
+                            <Label className="text-sm whitespace-nowrap">Proveedor:</Label>
+                            <Select
+                                value={proveedor ? String(proveedor) : "all"}
+                                onValueChange={(val) => setProveedor(val === "all" ? null : Number(val))}
+                            >
+                                <SelectTrigger className="h-8 text-sm w-48">
+                                    <SelectValue placeholder="Todos" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="all">Todos</SelectItem>
+                                    {providers.map((p) => (
+                                        <SelectItem key={p.id} value={String(p.id)}>
+                                            {p.nombre}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            <Label htmlFor="cxp-gr-plazo-inicio" className="text-sm whitespace-nowrap">Plazo desde:</Label>
+                            <input
+                                id="cxp-gr-plazo-inicio"
+                                type="date"
+                                value={fechaPlazoInicio}
+                                onChange={(e) => setFechaPlazoInicio(e.target.value)}
+                                className="h-8 px-2 rounded-md border border-border text-sm"
+                            />
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                            <Label htmlFor="cxp-gr-plazo-fin" className="text-sm whitespace-nowrap">Plazo hasta:</Label>
+                            <input
+                                id="cxp-gr-plazo-fin"
+                                type="date"
+                                value={fechaPlazoFin}
+                                onChange={(e) => setFechaPlazoFin(e.target.value)}
+                                className="h-8 px-2 rounded-md border border-border text-sm"
                             />
                         </div>
 

--- a/src/modules/cxp/screens/CxPListScreen.tsx
+++ b/src/modules/cxp/screens/CxPListScreen.tsx
@@ -49,6 +49,12 @@ const CxPListScreen = () => {
         setAppliedFilters({ ...filters, pagina: 1 });
     }, [filters]);
 
+    const handleReset = useCallback(() => {
+        const base: CxPPaginatedFilters = { pagina: 1, pagina_registros: 20 };
+        setFilters(base);
+        setAppliedFilters(base);
+    }, []);
+
     const calcularDiasVencimiento = (plazo_pago: string | null): number | null => {
         if (!plazo_pago) return null;
         const hoy = new Date();
@@ -250,6 +256,7 @@ const CxPListScreen = () => {
                     filters={filters}
                     onFilterChange={handleFilterChange}
                     onSearch={handleSearch}
+                    onReset={handleReset}
                     searchMode="manual"
                 />
             </header>

--- a/src/modules/cxp/screens/CxPRankingReportScreen.tsx
+++ b/src/modules/cxp/screens/CxPRankingReportScreen.tsx
@@ -10,7 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 import { subMonths, format } from "date-fns";
 import { formatCurrency } from "@/utils/formaters";
 import useCxPRankingReport, { useDownloadCxPRankingReport } from "../hooks/useCxPRankingReport";
-import type { CxPListItem, CxPRankingReportFilter } from "../schemas/cxpReport.schema";
+import type { CxPRankingItem, CxPRankingReportFilter } from "../schemas/cxpReport.schema";
 import authSDK from "@/services/sdk-simple-auth";
 import { ComboboxSelect } from "@/components/common/SelectCombobox";
 
@@ -46,15 +46,15 @@ const CxPRankingReportScreen = () => {
 
     const { mutate: downloadReport, isPending: isDownloading } = useDownloadCxPRankingReport();
 
-    const data = reportData?.data ?? [];
+    const data = reportData ?? [];
 
     const stats = useMemo(() => {
-        const totalCompra = data.reduce((sum, item) => sum + item.total_compra, 0);
-        const proveedoresUnicos = new Set(data.map((item) => item.proveedor.id)).size;
-        return { totalItems: data.length, totalCompra, proveedoresUnicos };
+        const totalVolumen = data.reduce((sum, item) => sum + item.volumen_compra, 0);
+        const proveedoresUnicos = new Set(data.map((item) => item.proveedor_id)).size;
+        return { totalItems: data.length, totalVolumen, proveedoresUnicos };
     }, [data]);
 
-    const columns = useMemo<ColumnDef<CxPListItem>[]>(
+    const columns = useMemo<ColumnDef<CxPRankingItem>[]>(
         () => [
             {
                 id: "ranking",
@@ -81,8 +81,7 @@ const CxPRankingReportScreen = () => {
                 },
             },
             {
-                id: "proveedor_nombre",
-                accessorFn: (row) => row.proveedor.nombre,
+                accessorKey: "proveedor",
                 header: "Proveedor",
                 size: 250,
                 minSize: 150,
@@ -91,16 +90,25 @@ const CxPRankingReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "nro_compra",
-                header: "Nro. Compra",
+                accessorKey: "nit",
+                header: "NIT",
                 size: 130,
                 minSize: 100,
                 cell: ({ getValue }) => (
-                    <div className="font-mono font-medium">{getValue<string>()}</div>
+                    <div className="font-mono text-sm">{getValue<string | null>() ?? "—"}</div>
                 ),
             },
             {
-                accessorKey: "total_compra",
+                accessorKey: "total_compras",
+                header: "Compras",
+                size: 100,
+                minSize: 80,
+                cell: ({ getValue }) => (
+                    <div className="text-center font-semibold">{getValue<number>()}</div>
+                ),
+            },
+            {
+                accessorKey: "volumen_compra",
                 header: "Volumen de Compra",
                 size: 160,
                 minSize: 120,
@@ -126,8 +134,8 @@ const CxPRankingReportScreen = () => {
                 ),
             },
             {
-                accessorKey: "saldo_pendiente",
-                header: "Saldo Pendiente",
+                accessorKey: "deuda_pendiente",
+                header: "Deuda Pendiente",
                 size: 140,
                 minSize: 100,
                 cell: ({ getValue }) => {
@@ -143,7 +151,7 @@ const CxPRankingReportScreen = () => {
         []
     );
 
-    const { table } = useCustomTable({
+    const { table } = useCustomTable<CxPRankingItem>({
         data,
         columns,
         enableSorting: true,
@@ -292,7 +300,7 @@ const CxPRankingReportScreen = () => {
                             {!appliedFilters
                                 ? "Presiona 'Buscar' para cargar el ranking"
                                 : data.length > 0
-                                ? `${stats.proveedoresUnicos} proveedores — ${formatCurrency(stats.totalCompra)} en compras`
+                                ? `${stats.proveedoresUnicos} proveedores — ${formatCurrency(stats.totalVolumen)} en compras`
                                 : "Sin resultados"}
                         </div>
 

--- a/src/modules/cxp/services/cxpReportService.ts
+++ b/src/modules/cxp/services/cxpReportService.ts
@@ -41,14 +41,13 @@ export const cxpReportService = {
     async getGeneralReport(
         filters: CxPGeneralReportFilter & { downloadable?: boolean },
     ): Promise<CxPGeneralReportResponse | Blob> {
-        Logger.info("Fetching CxP general report", { filters }, MODULE_NAME);
+        const { downloadable, ...backendFilters } = filters;
+        Logger.info("Fetching CxP general report", { filters: backendFilters }, MODULE_NAME);
 
-        const isDownloadable = filters.downloadable ?? false;
-
-        if (isDownloadable) {
+        if (downloadable) {
             const blob = await ApiService.post(
                 CXP_ENDPOINTS.reports.general,
-                filters,
+                backendFilters,
                 undefined,
                 ExcelRequestConfig(180000),
             );
@@ -58,7 +57,7 @@ export const cxpReportService = {
 
         const response = await ApiService.post(
             CXP_ENDPOINTS.reports.general,
-            filters,
+            backendFilters,
             CxPGeneralReportResponseSchema,
             { timeout: 120000 },
         );
@@ -75,14 +74,13 @@ export const cxpReportService = {
     async getBySupplierReport(
         filters: CxPBySupplierReportFilter & { downloadable?: boolean },
     ): Promise<CxPBySupplierReportResponse | Blob> {
-        Logger.info("Fetching CxP by-supplier report", { filters }, MODULE_NAME);
+        const { downloadable, ...backendFilters } = filters;
+        Logger.info("Fetching CxP by-supplier report", { filters: backendFilters }, MODULE_NAME);
 
-        const isDownloadable = filters.downloadable ?? false;
-
-        if (isDownloadable) {
+        if (downloadable) {
             const blob = await ApiService.post(
                 CXP_ENDPOINTS.reports.bySupplier,
-                filters,
+                backendFilters,
                 undefined,
                 ExcelRequestConfig(180000),
             );
@@ -92,7 +90,7 @@ export const cxpReportService = {
 
         const response = await ApiService.post(
             CXP_ENDPOINTS.reports.bySupplier,
-            filters,
+            backendFilters,
             CxPBySupplierReportResponseSchema,
             { timeout: 120000 },
         );
@@ -126,14 +124,13 @@ export const cxpReportService = {
     async getSupplierRankingReport(
         filters: CxPRankingReportFilter & { downloadable?: boolean },
     ): Promise<CxPRankingReportResponse | Blob> {
-        Logger.info("Fetching CxP supplier ranking report", { filters }, MODULE_NAME);
+        const { downloadable, ...backendFilters } = filters;
+        Logger.info("Fetching CxP supplier ranking report", { filters: backendFilters }, MODULE_NAME);
 
-        const isDownloadable = filters.downloadable ?? false;
-
-        if (isDownloadable) {
+        if (downloadable) {
             const blob = await ApiService.post(
                 CXP_ENDPOINTS.reports.supplierRanking,
-                filters,
+                backendFilters,
                 undefined,
                 ExcelRequestConfig(180000),
             );
@@ -143,11 +140,11 @@ export const cxpReportService = {
 
         const response = await ApiService.post(
             CXP_ENDPOINTS.reports.supplierRanking,
-            filters,
+            backendFilters,
             CxPRankingReportResponseSchema,
             { timeout: 120000 },
         );
-        Logger.info("CxP supplier ranking fetched successfully", { count: response.data.length }, MODULE_NAME);
+        Logger.info("CxP supplier ranking fetched successfully", { count: (response as CxPRankingReportResponse).length }, MODULE_NAME);
         return response as CxPRankingReportResponse;
     },
 };

--- a/src/modules/dashboard/screens/top-nav.tsx
+++ b/src/modules/dashboard/screens/top-nav.tsx
@@ -1,6 +1,11 @@
 import { Badge } from "@/components/atoms/badge";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/atoms/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/atoms/dropdown-menu";
 import { SidebarTrigger } from "@/components/atoms/sidebar";
 import NotificationsPanel from "@/components/common/NotificationsPanel";
 import ShortcutKey from "@/components/common/ShortcutKey";
@@ -17,6 +22,7 @@ import {
   Bell,
   ChevronDown,
   ChevronUp,
+  FileText,
   HelpCircle,
   MessageSquare,
   ShoppingCart,
@@ -215,6 +221,30 @@ const TopNav: React.FC<TopNavProps> = ({ onOpenCartChange }) => {
             <MessageSquare className="h-4 w-4" />
           </Button>
         </div>
+        {cart.sourceQuotation && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="relative size-8">
+                <FileText className="h-4 w-4 text-amber-500 dark:text-amber-400" />
+                <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-amber-400 dark:bg-amber-500" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-60 p-3 space-y-2">
+              <p className="text-xs font-semibold text-foreground">Cotización pendiente</p>
+              <p className="text-xs text-muted-foreground leading-relaxed">
+                La cotización <span className="font-medium text-foreground">#{cart.sourceQuotation.nro}</span> está siendo convertida a venta. Cancelá si querés empezar desde cero.
+              </p>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="w-full text-xs h-7"
+                onClick={() => cart.clearCart()}
+              >
+                Cancelar conversión
+              </Button>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         <Button
           variant="outline"
           className="relative size-8 cursor-pointer"

--- a/src/modules/quotations/schemas/quotationGetById.schema.ts
+++ b/src/modules/quotations/schemas/quotationGetById.schema.ts
@@ -40,6 +40,7 @@ export const QuotationGetByIdSchema = z.object({
     cliente_telefono: z.string().nullable(),
     cliente_nombre: z.string().nullable(),
     responsable_cotizacion: SaleResponsibleSchema.nullable(),
+    convertida: z.boolean().optional().default(false),
     caja_sesion_id: z.number().int().nullable().optional(),
     caja_sesion: z.object({
         id: z.number().int(),

--- a/src/modules/quotations/screens/quotationDetailScreen.tsx
+++ b/src/modules/quotations/screens/quotationDetailScreen.tsx
@@ -279,12 +279,16 @@ const QuotationDetailScreen = () => {
                       ? handleOpenCartClearAlert
                       : handleConvertToSale
                   }
-                  tooltip="Crear una venta a partir de esta cotización"
+                  tooltip={
+                    quotationData?.convertida
+                      ? "Esta cotización ya fue convertida a venta"
+                      : "Crear una venta a partir de esta cotización"
+                  }
                   buttonProps={{
-                    variant: "outline",
+                    variant: quotationData?.convertida ? "secondary" : "outline",
                     size: "sm",
                     className: "gap-2",
-                    disabled: isImporting,
+                    disabled: isImporting || quotationData?.convertida === true,
                   }}
                 >
                   {isImporting ? (
@@ -295,7 +299,7 @@ const QuotationDetailScreen = () => {
                   ) : (
                     <>
                       <ShoppingCart className="h-4 w-4" />
-                      Convertir a Venta
+                      {quotationData?.convertida ? "Ya convertida" : "Convertir a Venta"}
                     </>
                   )}
                 </TooltipButton>

--- a/src/modules/quotations/screens/quotationSelectorWindow.tsx
+++ b/src/modules/quotations/screens/quotationSelectorWindow.tsx
@@ -86,8 +86,10 @@ const QuotationSelectorWindow: React.FC = () => {
     resetFilters,
   } = useSalesFilters(Number(selectedBranchId) || 1);
 
-  const activeFilters =
-    searchMode === "realtime" ? debouncedFilters : appliedFilters;
+  const activeFilters = {
+    ...(searchMode === "realtime" ? debouncedFilters : appliedFilters),
+    sin_convertir: true as const,
+  };
 
   const {
     data: quotationData,

--- a/src/modules/sales/schemas/sales.schema.ts
+++ b/src/modules/sales/schemas/sales.schema.ts
@@ -35,5 +35,6 @@ export const SaleSchema = z.object({
   id_responsable: z.number(),
   detalles: z.array(SaleDetailSchema).nonempty('La venta debe tener al menos un detalle de producto'),
   formas_pago: z.array(SalePaymentMethodSchema).optional(),
+  cotizacion_id: z.number().int().positive().nullable().optional(),
 });
 export const SaleDetailListSchema = z.array(SaleDetailSchema).nonempty()

--- a/src/modules/sales/schemas/salesFilters.schema.ts
+++ b/src/modules/sales/schemas/salesFilters.schema.ts
@@ -9,4 +9,5 @@ export const salesFiltersSchema = baseFilterSchema.extend({
     fecha_inicio: z.preprocess(toDateOrUndefined, z.date().optional()),
     fecha_fin: z.preprocess(toDateOrUndefined, z.date().optional()),
     codigo_oem_producto: z.preprocess(toUndefinedIfEmpty, z.string().optional()),
+    sin_convertir: z.boolean().optional(),
 })

--- a/src/modules/sales/screens/createSaleScreen.tsx
+++ b/src/modules/sales/screens/createSaleScreen.tsx
@@ -181,6 +181,8 @@ const CreateSaleScreen = () => {
     mode,
     setCartMode,
     previewConversion,
+    sourceQuotation,
+    setSourceQuotation,
   } = useCartWithUtils(user?.name || "", selectedBranchId ?? "");
 
   const {
@@ -552,6 +554,7 @@ const CreateSaleScreen = () => {
       ...data,
       fecha: formatDateForSubmission(data.fecha),
       ...(isContado && formasPago.length > 0 ? { formas_pago: formasPago } : {}),
+      cotizacion_id: sourceQuotation?.id ?? null,
     };
 
     createSale(dataToSend, {
@@ -561,6 +564,8 @@ const CreateSaleScreen = () => {
           description: `Venta #${createdSale.nro || createdSale.id} creada exitosamente`,
           duration: 2000,
         });
+
+        setSourceQuotation(null);
 
         // editar tab con la venta creada
         const currentTab = tabs.find((t) => t.id === activeTabId);
@@ -665,6 +670,13 @@ const CreateSaleScreen = () => {
     getValues,
     setValue,
   ]);
+
+  useEffect(() => {
+    if (!sourceQuotation && creationMode === "quotation-import") {
+      setCreationMode("manual");
+      setSelectedQuotationId(null);
+    }
+  }, [sourceQuotation, creationMode]);
 
   const selectedItems = useMemo<SelectedItem[]>(() => {
     return detalles.map((detail) => ({

--- a/src/modules/shoppingCart/hooks/useCartWithUtils.ts
+++ b/src/modules/shoppingCart/hooks/useCartWithUtils.ts
@@ -44,6 +44,10 @@ export const useCartWithUtils = (user: string, branch: string) => {
         });
     }, [state.setMode]);
 
+    const setCartModeSilent = useCallback((mode: CartMode) => {
+        state.setMode(mode);
+    }, [state.setMode]);
+
     const convertToSaleStrictWithToast = useCallback((): ConversionResult => {
         const result = state.convertToSaleStrict();
 
@@ -134,9 +138,24 @@ export const useCartWithUtils = (user: string, branch: string) => {
             );
 
             if (result.success) {
+                if (!result.data?.imported) {
+                    showErrorToast({
+                        title: "Sin stock disponible",
+                        description: `Ningún producto de la cotización #${quotation.nro} tiene stock disponible para importar`,
+                        duration: 3000
+                    });
+                    return { success: false, error: 'NO_STOCK', message: 'Sin stock disponible' };
+                }
+
+                state.setSourceQuotation({ id: quotation.id, nro: quotation.nro });
+
                 const messages: string[] = [
-                    `Se importaron ${result.data?.imported} productos de la cotización #${quotation.nro}`
+                    `Se importaron ${result.data.imported} productos de la cotización #${quotation.nro}`
                 ];
+
+                if (result.data.removed > 0) {
+                    messages.push(`${result.data.removed} sin stock (removidos)`);
+                }
 
                 if (discountInfo.hasDiscount) {
                     messages.push(
@@ -168,7 +187,7 @@ export const useCartWithUtils = (user: string, branch: string) => {
 
             return result;
         }
-    }, [state.importFromQuotation]);
+    }, [state.importFromQuotation, state.setSourceQuotation]);
 
     // ==================== GESTIÓN DE ITEMS ====================
 
@@ -653,6 +672,7 @@ export const useCartWithUtils = (user: string, branch: string) => {
 
         // Métodos de modo
         setCartMode,
+        setCartModeSilent,
         convertToSaleStrictWithToast,
         convertToSalePermissiveWithToast,
         convertToQuoteWithToast,

--- a/src/modules/shoppingCart/hooks/useQuotationImport.ts
+++ b/src/modules/shoppingCart/hooks/useQuotationImport.ts
@@ -40,7 +40,7 @@ export const useQuotationImport = (
   const user = authSDK.getCurrentUser();
   const selectedBranchId = useBranchStore((s) => s.selectedBranchId);
 
-  const { setCartMode, previewQuotationImport, importFromQuotation } =
+  const { setCartModeSilent, previewQuotationImport, importFromQuotation } =
     useCartWithUtils(user?.name || "", selectedBranchId ?? "");
 
   const [isImporting, setIsImporting] = useState(false);
@@ -85,7 +85,6 @@ export const useQuotationImport = (
           setShowConversionModal(true);
         } else {
           // No hay cambios, importar directamente en modo strict
-          setCartMode("sale-strict");
           executeImport(quotation, formData, "sale-strict");
           setIsImporting(false);
           onImportComplete?.();
@@ -102,7 +101,6 @@ export const useQuotationImport = (
       user?.name,
       selectedBranchId,
       onImportComplete,
-      setCartMode,
     ],
   );
 
@@ -116,7 +114,7 @@ export const useQuotationImport = (
       importMode: CartMode,
     ) => {
       try {
-        setCartMode(importMode);
+        setCartModeSilent(importMode);
 
         importFromQuotation(quotation);
 
@@ -143,7 +141,7 @@ export const useQuotationImport = (
         console.error("Error al ejecutar importación:", error);
       }
     },
-    [importFromQuotation, setValue, setCartMode],
+    [importFromQuotation, setValue, setCartModeSilent],
   );
 
   /**

--- a/src/modules/shoppingCart/store/cartStore.ts
+++ b/src/modules/shoppingCart/store/cartStore.ts
@@ -34,11 +34,16 @@ export const createCartStore = (user: string) => {
           discountPercent: 0,
           discountMode: null,
           lastConversion: null,
+          sourceQuotation: null,
 
           // ==================== GESTIÓN DE MODO ====================
 
           setMode: (mode) => {
             set({ mode });
+          },
+
+          setSourceQuotation: (q) => {
+            set({ sourceQuotation: q });
           },
 
           convertToSaleStrict: () => {
@@ -541,6 +546,7 @@ export const createCartStore = (user: string) => {
               discountPercent: 0,
               discountMode: null,
               lastConversion: null,
+              sourceQuotation: null,
             }),
 
           // ==================== GESTIÓN DE DESCUENTOS ====================

--- a/src/modules/shoppingCart/types/cart.types.ts
+++ b/src/modules/shoppingCart/types/cart.types.ts
@@ -11,6 +11,11 @@ export interface ConversionAdjustment {
   reason: "QUANTITY_ADJUSTED" | "REMOVED_NO_STOCK";
 }
 
+export interface SourceQuotation {
+  id: number;
+  nro: string;
+}
+
 export interface ConversionResult {
   success: boolean;
   removedItems: CartItem[];
@@ -85,9 +90,11 @@ export type CartState = {
   discountPercent: number;
   discountMode: DiscountMode;
   lastConversion: ConversionResult | null;
+  sourceQuotation: SourceQuotation | null;
 
   // Gestión de modo
   setMode: (mode: CartMode) => void;
+  setSourceQuotation: (q: SourceQuotation | null) => void;
   convertToSaleStrict: () => ConversionResult;
   convertToSalePermissive: () => void;
   convertToQuote: () => void;

--- a/src/modules/users/services/userService.ts
+++ b/src/modules/users/services/userService.ts
@@ -73,23 +73,7 @@ export const fetchUserPermissions = async (userId: number): Promise<Permission[]
 };
 
 export const updateUserPermissions = async (userPermissionsData: UserPermissionsRequest): Promise<void> => {
-  try {
-    // console.log('🚀 Enviando permisos de usuario al servidor:', userPermissionsData);
-    const response = await apiClient.put(USER_ENDPOINTS.updatePermissions, userPermissionsData);
-    // console.log('✅ Respuesta del servidor (permisos):', response.data);
-  } catch (error: any) {
-    console.error("❌ Error al actualizar permisos de usuario:", error);
-
-    if (error.response?.status === 422 && error.response?.data?.error?.validation_errors) {
-      // console.group('🔍 Errores de validación:');
-      // error.response.data.error.validation_errors.forEach((validationError: any, index: number) => {
-      //   console.log(`${index + 1}. Campo: ${validationError.field} - ${validationError.message}`);
-      // });
-      // console.groupEnd();
-    }
-
-    throw new Error("Error al actualizar los permisos del usuario");
-  }
+  await apiClient.put(USER_ENDPOINTS.updatePermissions, userPermissionsData);
 };
 
 /**

--- a/src/navigation/Finance.Route.ts
+++ b/src/navigation/Finance.Route.ts
@@ -1,19 +1,16 @@
 import CxPListScreen from "@/modules/cxp/screens/CxPListScreen";
-import CxPProjectionScreen from "@/modules/cxp/screens/CxPProjectionScreen";
+// import CxPProjectionScreen from "@/modules/cxp/screens/CxPProjectionScreen"; // backend sin datos aún
 import CxPGeneralReportScreen from "@/modules/cxp/screens/CxPGeneralReportScreen";
 import CxPBySupplierReportScreen from "@/modules/cxp/screens/CxPBySupplierReportScreen";
 import CxPRankingReportScreen from "@/modules/cxp/screens/CxPRankingReportScreen";
-import AlertsScreen from "@/modules/alerts/screens/AlertsScreen";
-import TreasuryDashboardScreen from "@/modules/treasury/screens/TreasuryDashboardScreen";
+// import AlertsScreen from "@/modules/alerts/screens/AlertsScreen"; // backend WIP
+// import TreasuryDashboardScreen from "@/modules/treasury/screens/TreasuryDashboardScreen"; // backend WIP
 import {
   Landmark,
   TableCellsMerge,
-  TrendingDown,
   FileText,
   Users,
   Trophy,
-  Bell,
-  Vault,
 } from "lucide-react";
 import type RouteType from "./RouteType";
 
@@ -38,17 +35,11 @@ const financeRoutes: RouteType[] = [
         isHeader: false,
         showSidebar: true,
       },
-      {
-        path: "/dashboard/cxp/projection",
-        name: "Proyección de Pagos",
-        type: "protected",
-        element: CxPProjectionScreen,
-        isAdmin: false,
-        role: ["Administrador", "Super Admin"],
-        icon: TrendingDown,
-        isHeader: false,
-        showSidebar: true,
-      },
+      // {
+      //   path: "/dashboard/cxp/projection",
+      //   name: "Proyección de Pagos",
+      //   element: CxPProjectionScreen,  // backend sin datos — comentado temporalmente
+      // },
       {
         path: "/dashboard/cxp/reports/general",
         name: "Reporte General CxP",
@@ -82,28 +73,8 @@ const financeRoutes: RouteType[] = [
         isHeader: false,
         showSidebar: true,
       },
-      {
-        path: "/dashboard/alerts",
-        name: "Alertas de Mora",
-        type: "protected",
-        element: AlertsScreen,
-        isAdmin: false,
-        role: ["Administrador", "Vendedor", "Super Admin", "Invitado"],
-        icon: Bell,
-        isHeader: false,
-        showSidebar: true,
-      },
-      {
-        path: "/dashboard/treasury",
-        name: "Tesorería",
-        type: "protected",
-        element: TreasuryDashboardScreen,
-        isAdmin: false,
-        role: ["Administrador", "Super Admin"],
-        icon: Vault,
-        isHeader: false,
-        showSidebar: true,
-      },
+      // Alerts: backend WIP
+      // Treasury: backend WIP
     ],
   },
 ];

--- a/src/navigation/Protected.Route.ts
+++ b/src/navigation/Protected.Route.ts
@@ -1,7 +1,7 @@
 import { LayoutDashboardIcon } from "lucide-react";
 import accountsReceivable from "./AccountReceivable.Route";
 import cashProtectedRoutes from "./Cash.Route";
-// import financeRoutes from "./Finance.Route"; // WIP: cxp/alerts/treasury backend not ready
+import financeRoutes from "./Finance.Route";
 import ordersProtectedRoutes from "./Order.Route";
 import productosProtectedRoutes from "./Productos.Route";
 import purchasesProtectedRoutes from "./Purchases.Route";
@@ -37,7 +37,7 @@ const protectedRoutes: RouteType[] = [
   ...settingsProtectedRoutes,
   ...transfersProtectedRoutes,
   ...accountsReceivable,
-  // ...financeRoutes, // WIP: cxp/alerts/treasury backend not ready
+  ...financeRoutes,
 ];
 
 export default protectedRoutes;

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,5 +1,9 @@
 import authSDK from "@/services/sdk-simple-auth";
 import { useTabStore } from "@/states/tabStore";
+
+const isSecondaryWindow =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).get("windowId") !== null;
 import { cleanFilters } from "@/utils/cleanFilters";
 import { environment } from "@/utils/environment";
 import {
@@ -63,7 +67,7 @@ apiClient.interceptors.request.use(
     config.startTime = Date.now();
 
     // Autenticación
-    const token = await authSDK.getAccessToken();
+    const token = await authSDK.getValidAccessToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -206,12 +210,17 @@ apiClient.interceptors.response.use(
             requestId,
             status,
             url: formattedError.fullUrl,
+            isSecondaryWindow,
           }),
         );
 
-        // Limpiar todas las tabs
-        useTabStore.getState().closeAllTabs();
-        await authSDK.clearLocalSession();
+        // Secondary windows never own auth state — clearing the shared IndexedDB here
+        // would destroy the main window's session via tabSync broadcast.
+        // Auth cleanup is the main window's responsibility exclusively.
+        if (!isSecondaryWindow) {
+          useTabStore.getState().closeAllTabs();
+          await authSDK.clearLocalSession();
+        }
       }
     }
 

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,4 +1,3 @@
-import type { ApiError } from "@/types/apiError.types";
 import { AxiosError } from "axios";
 
 interface ErrorResult {
@@ -7,9 +6,67 @@ interface ErrorResult {
     category: "validation" | "network" | "server" | "authentication" | "unknown";
 }
 
-// 👇 Type Guard para validar si la respuesta tiene el formato esperado
-export function isApiErrorResponse(data: unknown): data is { error: ApiError } {
-    return typeof data === "object" && data !== null && "error" in data;
+/**
+ * Extrae un mensaje legible del body de respuesta del backend.
+ * Prueba formatos en orden de prioridad y devuelve undefined si ninguno aplica,
+ * dejando que el fallback por status code tome el control.
+ *
+ * Formatos soportados (en orden de prioridad):
+ *   1. { error: { validation_errors: [{field, message}] } }  → formato ApiError propio con campos
+ *   2. { error: { message: "..." } }                         → formato ApiError propio sin campos
+ *   3. { errors: { campo: ["msg"] } }                        → Laravel estándar 422
+ *   4. { message: "..." }                                    → mensaje simple
+ *   5. string plano (no HTML)                                → respuesta directa
+ */
+function parseResponseMessage(data: unknown): string | undefined {
+    if (typeof data === "string") {
+        const trimmed = data.trim();
+        if (trimmed && !trimmed.startsWith("<") && trimmed.length <= 300) {
+            return trimmed;
+        }
+        return undefined;
+    }
+
+    if (!data || typeof data !== "object") return undefined;
+
+    const d = data as Record<string, unknown>;
+
+    // Formato propio: { error: { validation_errors: [{field, message}], message } }
+    if (d.error && typeof d.error === "object") {
+        const nested = d.error as Record<string, unknown>;
+
+        if (Array.isArray(nested.validation_errors) && nested.validation_errors.length > 0) {
+            const messages = (nested.validation_errors as Array<Record<string, unknown>>)
+                .map((e) => (typeof e.message === "string" ? e.message.trim() : ""))
+                .filter(Boolean)
+                .slice(0, 3);
+            if (messages.length > 0) {
+                return messages.join(" • ");
+            }
+        }
+
+        if (typeof nested.message === "string" && nested.message.trim()) {
+            return nested.message.trim();
+        }
+    }
+
+    // Laravel estándar: { errors: { campo: ["msg1", "msg2"] } }
+    if (d.errors && typeof d.errors === "object" && !Array.isArray(d.errors)) {
+        const fieldErrors = Object.values(d.errors as Record<string, unknown>)
+            .flatMap((v) => (Array.isArray(v) ? v : [v]))
+            .filter((m): m is string => typeof m === "string" && m.trim().length > 0)
+            .slice(0, 3);
+        if (fieldErrors.length > 0) {
+            return fieldErrors.join(" • ");
+        }
+    }
+
+    // Mensaje simple: { message: "..." }
+    if (typeof d.message === "string" && d.message.trim()) {
+        return d.message.trim();
+    }
+
+    return undefined;
 }
 
 export class ErrorHandler {
@@ -20,8 +77,7 @@ export class ErrorHandler {
 
         if (error instanceof Error) {
             return {
-                userMessage:
-                    "Algo salió mal. Si el problema persiste, contacta soporte.",
+                userMessage: "Algo salió mal. Si el problema persiste, contacta soporte.",
                 shouldRetry: false,
                 category: "unknown",
             };
@@ -35,34 +91,21 @@ export class ErrorHandler {
     }
 
     private static handleAxiosError(error: AxiosError): ErrorResult {
-        // Error de red
         if (!error.response) {
             return {
-                userMessage:
-                    "Problema de conexión. Verifica tu internet e inténtalo de nuevo.",
+                userMessage: "Problema de conexión. Verifica tu internet e inténtalo de nuevo.",
                 shouldRetry: true,
                 category: "network",
             };
         }
 
-        // 👇 Validamos la forma de la respuesta antes de acceder
-        // let apiError: ApiError | undefined;
-        // if (isApiErrorResponse(error.response.data)) {
-        //     apiError = error.response.data.error;
-        // }
-
         const status = error.response.status;
-        // const serverMessage = apiError?.message;
+        const serverMessage = parseResponseMessage(error.response.data);
 
-        // return this.handleByStatus(status, serverMessage);
-        return this.handleByStatus(status);
+        return this.handleByStatus(status, serverMessage);
     }
 
-    private static handleByStatus(
-        status: number,
-        serverMessage?: string,
-        // validationErrors?: ValidationError[]
-    ): ErrorResult {
+    private static handleByStatus(status: number, serverMessage?: string): ErrorResult {
         switch (status) {
             case 400:
                 return {
@@ -93,15 +136,6 @@ export class ErrorHandler {
                 };
 
             case 422:
-                // let message = serverMessage || "Corrige los siguientes errores:";
-
-                // if (validationErrors?.length) {
-                //     const errors = validationErrors
-                //         .map((err) => `• ${err.message}`)
-                //         .join("\n");
-                //     message += `\n\n${errors}`;
-                // }
-
                 return {
                     userMessage: serverMessage || "Algunos datos no son válidos, por favor revisa e intenta de nuevo.",
                     shouldRetry: false,
@@ -120,8 +154,7 @@ export class ErrorHandler {
             case 503:
             case 504:
                 return {
-                    userMessage:
-                        serverMessage || "Problemas técnicos temporales. Inténtalo en unos minutos.",
+                    userMessage: serverMessage || "Problemas técnicos temporales. Inténtalo en unos minutos.",
                     shouldRetry: true,
                     category: "server",
                 };

--- a/src/window-entry.tsx
+++ b/src/window-entry.tsx
@@ -94,23 +94,36 @@ const requiresAuth = componentId
   : true;
 
 if (rootElement) {
-  createRoot(rootElement).render(
-    requiresAuth ? (
-      <AuthSDKContext.Provider value={windowAuthSDK ?? authSDK}>
-        <TaskNotificationsProvider>
-          <WebSocketProvider>
-            <WindowLayout>
-              <WindowComponentRenderer />
-            </WindowLayout>
-          </WebSocketProvider>
-        </TaskNotificationsProvider>
-      </AuthSDKContext.Provider>
-    ) : (
-      <WindowComponentRenderer />
-    )
-  );
+  const mount = () => {
+    createRoot(rootElement).render(
+      requiresAuth ? (
+        <AuthSDKContext.Provider value={windowAuthSDK ?? authSDK}>
+          <TaskNotificationsProvider>
+            <WebSocketProvider>
+              <WindowLayout>
+                <WindowComponentRenderer />
+              </WindowLayout>
+            </WebSocketProvider>
+          </TaskNotificationsProvider>
+        </AuthSDKContext.Provider>
+      ) : (
+        <WindowComponentRenderer />
+      )
+    );
+  };
 
-  console.log("[WindowEntry] ✅ Aplicación renderizada");
+  if (isSecondaryWindow && requiresAuth) {
+    authSDK.ready
+      .then(() => {
+        mount();
+      })
+      .catch((error) => {
+        console.error("[WindowEntry] ❌ SDK ready failed:", error);
+        mount();
+      });
+  } else {
+    mount();
+  }
 } else {
   console.error("[WindowEntry] ❌ No se encontró el elemento #window-root");
 }


### PR DESCRIPTION
…dow auth fix

CxP filters:
- List: add exact due-date filter (>=, <=, =) with operator select; grid 6→4 cols
- General report: add proveedor and plazo date range filters
- By-supplier report: add proveedor filter
- Hide Proyección de Pagos from nav (no backend data yet)

Quotation → Sale flow:
- Track sourceQuotation in cart store + TopNav badge with cancel button
- Quotation detail: disable convert button and show "Ya convertida" when convertida=true
- Quotation selector window: filter sin_convertir=true by default
- createSaleScreen: send cotizacion_id when creating from a quotation; clear sourceQuotation on success
- useQuotationImport: switch to setCartModeSilent to suppress mode-change toast during import
- importFromQuotation: guard against zero-stock imports with specific error toast

Auth fix (secondary windows):
- axios: use getValidAccessToken() (async) instead of getAccessToken() (sync)
- axios: guard clearLocalSession() with !isSecondaryWindow to avoid destroying main session
- window-entry: await authSDK.ready before mounting secondary windows that require auth

Error handling:
- errorHandler: parse real backend messages (validation_errors, Laravel 422, plain message)
- userService: remove redundant try/catch that swallowed backend error details

Caja schema:
- Add ANULACION_PAGO_PROVEEDOR concept
- Add grupo_cobro field (nullable, optional)

Cleanup:
- Remove debug console.log calls from axios interceptors and window-entry