### PR TITLE
fix(tauri): add port wildcard to CSP connect-src for non-standard ports

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; connect-src 'self' ipc: http://ipc.localhost http://* https://* ws://* wss://*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://* https://*; frame-src 'self' blob:; media-src 'self' blob: data:;",
+      "csp": "default-src 'self' ipc: http://ipc.localhost; connect-src 'self' ipc: http://ipc.localhost http://*:* https://*:* ws://*:* wss://*:*; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: http://* https://*; frame-src 'self' blob:; media-src 'self' blob: data:;",
       "capabilities": ["default"]
     },
     "withGlobalTauri": true


### PR DESCRIPTION
Add port wildcard to CSP connect-src for non-standard ports