### PR TITLE
feat(transfers): transfer request feature via chat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tps-intermotors",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tps-intermotors",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@dnd-kit/modifiers": "9.0.0",

--- a/src/components/atoms/dialog.tsx
+++ b/src/components/atoms/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9999] bg-black/50  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/50  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -130,6 +130,11 @@ export const PERMISSIONS = {
     DETAIL_CREATE: 'tra-detail_create',
     DETAIL_DELETE: 'tra-detail_delete',
     DETAIL_EDIT: 'tra-detail_edit',
+    // ─── Solicitudes de Transferencia (Transfer Requests) ───────────────────
+    REQUEST_CREATE: 'tra-request_create',
+    REQUEST_VIEW: 'tra-request_view',
+    REQUEST_FULFILL: 'tra-request_fulfill',
+    REQUEST_IMPORT: 'tra-request_import',
   },
 
   // ─── CUENTAS POR COBRAR (CUC / CxC) ─────────────────────────────────────────

--- a/src/modules/dashboard/screens/appSidebar.tsx
+++ b/src/modules/dashboard/screens/appSidebar.tsx
@@ -26,6 +26,7 @@ import NavItem from "../components/NavItem";
 import logoLight from "@/assets/images/logo_light.webp";
 import logoDark from "@/assets/images/darkmodeweb.webp";
 import { Button } from "@/components/atoms/button";
+import { queryClient } from "@/lib/reactQueryConfig";
 
 const AppSidebar = () => {
   const [expandedHeaders, setExpandedHeaders] = useState<string[]>([]);
@@ -52,6 +53,7 @@ const AppSidebar = () => {
     try {
       // Limpiar todas las tabs antes del logout
       closeAllTabs();
+      queryClient.clear();
       // localStorage.removeItem("lastPath"); ///POR SI QUEREMOS BORRAR HISTORIAL DE ULTIMA RUTA
       await authSDK.logout();
     } catch (error) {

--- a/src/modules/messaging/components/AttachmentMessage.tsx
+++ b/src/modules/messaging/components/AttachmentMessage.tsx
@@ -96,14 +96,14 @@ function ImageAttachment({
         style={{
           aspectRatio,
           minHeight,
-          maxHeight: 260,
-          maxWidth: 280,
+          maxHeight: 300,
+          maxWidth: 360,
           width: "100%",
         }}
       >
-        {/* Skeleton */}
-        {!imgLoaded && !isFailed && (
-          <Skeleton className=" absolute inset-0 rounded-xl bg-muted/50 flex items-center justify-center">
+        {/* Skeleton mientras carga (no durante upload fallido) */}
+        {!imgLoaded && !isUploading && !isFailed && (
+          <Skeleton className="absolute inset-0 rounded-xl bg-muted/50 flex items-center justify-center">
             <Image className="size-12 text-muted-foreground" />
           </Skeleton>
         )}
@@ -114,12 +114,10 @@ function ImageAttachment({
           alt={attachment.nombre_original}
           onLoad={() => setImgLoaded(true)}
           className={cn(
-            "block w-full h-full object-cover rounded-xl cursor-pointer transition-opacity duration-300",
-            (!imgLoaded || isUploading || isFailed) && "opacity-0",
-            imgLoaded &&
-              !isUploading &&
-              !isFailed &&
-              "opacity-100 hover:opacity-90"
+            "block w-full h-full object-cover rounded-xl transition-opacity duration-300",
+            (!imgLoaded || isUploading) && "opacity-0",
+            imgLoaded && !isUploading && !isFailed && "cursor-pointer opacity-100 hover:opacity-90",
+            imgLoaded && isFailed && "opacity-60 cursor-default",
           )}
           draggable={false}
           onClick={() =>
@@ -147,18 +145,16 @@ function ImageAttachment({
           </div>
         )}
 
-        {/* Overlay de error */}
+        {/* Overlay de error — imagen visible con botón centrado (estilo WhatsApp) */}
         {isFailed && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center rounded-xl bg-black/50 gap-2">
-            <AlertCircle className="h-6 w-6 text-destructive" />
-            <span className="text-[10px] text-white">Error al subir</span>
+          <div className="absolute inset-0 flex items-center justify-center rounded-xl bg-black/30">
             {onRetry && (
               <button
                 onClick={onRetry}
-                className="rounded-lg bg-white/20 px-3 py-1 text-[10px] font-semibold text-white hover:bg-white/30 transition-colors"
+                className="flex h-11 w-11 items-center justify-center rounded-full bg-white/95 shadow-lg transition-all hover:scale-105 hover:bg-white active:scale-95"
+                title="Reintentar"
               >
-                <RotateCcw className="h-3 w-3" />
-                Reintentar
+                <RotateCcw className="h-5 w-5 text-gray-800" />
               </button>
             )}
           </div>
@@ -254,19 +250,13 @@ function FileChip({
         className={cn(
           "mt-1.5 flex items-center gap-2 rounded-xl border p-2 min-w-[200px] max-w-[280px]",
           isMine
-            ? "border-background/10 bg-background/20"
-            : "border-border/50 bg-card/50",
-          isFailed && "border-destructive/30 bg-destructive/5",
+            ? "border-border/40 bg-muted shadow-[0_4px_16px_rgba(0,0,0,0.2)] ring-1 ring-black/[0.07]"
+            : "border-border bg-card shadow-md",
           isClickable && "cursor-pointer hover:opacity-80 transition-opacity"
         )}
       >
         {/* Icono */}
-        <div
-          className={cn(
-            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
-            isMine ? "bg-background/10" : "bg-muted-foreground/10"
-          )}
-        >
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-muted-foreground/10">
           {isUploading ? (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           ) : isFailed ? (
@@ -280,19 +270,11 @@ function FileChip({
         <div className="min-w-0 flex-1">
           <p
             title={attachment.nombre_original}
-            className={cn(
-              "truncate text-[12px] font-semibold",
-              isMine ? "text-primary-foreground" : "text-foreground"
-            )}
+            className="truncate text-[12px] font-semibold text-foreground"
           >
             {attachment.nombre_original}
           </p>
-          <p
-            className={cn(
-              "text-[10px]",
-              isMine ? "text-primary-foreground/60" : "text-muted-foreground"
-            )}
-          >
+          <p className={cn("text-[10px]", isFailed ? "text-destructive" : "text-muted-foreground")}>
             {isFailed
               ? "Error al subir"
               : isUploading && progress !== undefined
@@ -319,7 +301,7 @@ function FileChip({
               e.stopPropagation();
               onRetry();
             }}
-            className="shrink-0 flex items-center gap-1 rounded-lg border border-destructive/30 px-2 py-1 text-[10px] text-destructive hover:bg-destructive/10 transition-colors"
+            className="shrink-0 flex items-center gap-1.5 rounded-lg bg-destructive px-2.5 py-1.5 text-[10px] font-semibold text-white hover:bg-destructive/90 active:bg-destructive/80 transition-colors"
           >
             <RotateCcw className="h-3 w-3" />
             Reintentar
@@ -332,12 +314,7 @@ function FileChip({
             }}
             variant="ghost"
             disabled={isDownloading}
-            className={cn(
-              "shrink-0 h-7 w-7",
-              isMine
-                ? "text-primary-foreground/70 hover:bg-primary-foreground/15 hover:text-primary-foreground"
-                : "text-muted-foreground hover:bg-accent hover:text-foreground"
-            )}
+            className="shrink-0 h-7 w-7 text-muted-foreground hover:bg-accent hover:text-foreground"
             title="Descargar"
           >
             {isDownloading ? (

--- a/src/modules/messaging/components/ChatConversation.tsx
+++ b/src/modules/messaging/components/ChatConversation.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   ArrowLeft,
   Send,
@@ -21,6 +22,10 @@ import {
   Dot,
   UserX,
   Trash2,
+  Paperclip,
+  PackagePlus,
+  ImageIcon,
+  FileText,
 } from "lucide-react";
 import { Button } from "@/components/atoms/button";
 import {
@@ -28,6 +33,14 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/atoms/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/atoms/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { useChatStore, selectActiveChat } from "../stores/ChatStore";
 import { useOpenChat } from "../hooks/useActiveChat";
@@ -45,8 +58,9 @@ import { isExMember } from "../types/Chat.types";
 import { DateSeparator } from "./DateSeparator";
 import { useDraftStore } from "../stores/DraftStore";
 import { useSendAttachment } from "../hooks/useSendAttachment";
-import { FilePickerButton } from "./FilePickerButton";
 import { isImageMime, validateAttachment } from "../types/Attachment.types";
+import { smartCompressToWebP, fileToBase64, base64ToFile } from "@/utils/imageCompression";
+import { isTauriEnvironment } from "@/utils/environment";
 import { AttachmentComposer } from "./AttachmentComposer";
 import { ConversationAvatar } from "./ConversationAvatar";
 import authSDK from "@/services/sdk-simple-auth";
@@ -213,6 +227,19 @@ interface Props {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// HELPERS
+// ─────────────────────────────────────────────────────────────────────────────
+
+function readImageDimensions(
+  blobUrl: string,
+  onDimensions: (dims: { width: number; height: number }) => void,
+) {
+  const img = new window.Image();
+  img.onload = () => onDimensions({ width: img.naturalWidth, height: img.naturalHeight });
+  img.src = blobUrl;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // COMPONENT
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -222,12 +249,15 @@ export function ChatConversation({
   infoActive: infoActiveProp,
   onToggleInfo: onToggleInfoProp,
 }: Props) {
+  const navigate = useNavigate();
   const currentUserId = authSDK.getCurrentUser()?.id;
   const chat = useChatStore(selectActiveChat);
   const setActiveChatId = useChatStore((s) => s.setActiveChatId);
   const isOnline = useOfflineQueueStore((s) => s.isOnline);
   const pendingCount = useOfflineQueueStore((s) => s.queue.length);
   const pendingFileRef = useRef<File | null>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const documentInputRef = useRef<HTMLInputElement>(null);
 
   // ── Estado de ex-miembro ──────────────────────────────────────────────────
   const exMember = chat ? isExMember(chat) : false;
@@ -239,8 +269,8 @@ export function ChatConversation({
   const toggleInfo = onToggleInfoProp ?? (() => setShowInfoInternal((v) => !v));
   const closeInfo = onToggleInfoProp
     ? () => {
-        if (infoActiveProp) onToggleInfoProp();
-      }
+      if (infoActiveProp) onToggleInfoProp();
+    }
     : () => setShowInfoInternal(false);
 
   const [replyTo, setReplyTo] = useState<Message | OptimisticMessage | null>(
@@ -272,6 +302,7 @@ export function ChatConversation({
 
   // ── Scroll ─────────────────────────────────────────────────────────────────
   const scrollRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isAtBottomRef = useRef(true);
   const prevScrollHeightRef = useRef<number | null>(null);
@@ -308,14 +339,20 @@ export function ChatConversation({
   const [pendingPreviewUrl, setPendingPreviewUrl] = useState<string | null>(
     null
   );
+  const [pendingImageDimensions, setPendingImageDimensions] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
   const [attachError, setAttachError] = useState<string | null>(null);
   const [isUploadingSending, setIsUploadingSending] = useState(false);
+  const [isCompressing, setIsCompressing] = useState(false);
 
   const clearPendingFile = useCallback(() => {
     pendingFileRef.current = null;
     if (pendingPreviewUrl) URL.revokeObjectURL(pendingPreviewUrl);
     setPendingFile(null);
     setPendingPreviewUrl(null);
+    setPendingImageDimensions(null);
     setAttachError(null);
     setIsUploadingSending(false);
   }, [pendingPreviewUrl]);
@@ -327,16 +364,52 @@ export function ChatConversation({
     [pendingPreviewUrl]
   );
 
-  const handleFileSelected = (file: File) => {
+  const handleFileSelected = async (file: File) => {
+    setIsUploadingSending(false);
+
+    if (isImageMime(file.type) && isTauriEnvironment()) {
+      setIsCompressing(true);
+      try {
+        const base64 = await fileToBase64(file);
+        const result = await smartCompressToWebP(base64, { quality: 82, effort: 4 });
+        const baseName = file.name.replace(/\.[^.]+$/, "");
+        const compressed = base64ToFile(result.data, `${baseName}.webp`);
+        pendingFileRef.current = compressed;
+        const previewUrl = URL.createObjectURL(compressed);
+        const validation = validateAttachment(compressed);
+        setPendingFile(compressed);
+        setPendingPreviewUrl(previewUrl);
+        setAttachError(validation.valid ? null : validation.error);
+        readImageDimensions(previewUrl, setPendingImageDimensions);
+      } catch {
+        // Fallback: usar imagen original sin comprimir
+        pendingFileRef.current = file;
+        const validation = validateAttachment(file);
+        const previewUrl = URL.createObjectURL(file);
+        setPendingFile(file);
+        setPendingPreviewUrl(previewUrl);
+        setAttachError(validation.valid ? null : validation.error);
+        readImageDimensions(previewUrl, setPendingImageDimensions);
+      } finally {
+        setIsCompressing(false);
+      }
+      return;
+    }
+
+    // Documentos o entorno no-Tauri: sin compresión
     pendingFileRef.current = file;
     const validation = validateAttachment(file);
-    const previewUrl = isImageMime(file.type)
-      ? URL.createObjectURL(file)
-      : null;
-    setPendingFile(file);
-    setPendingPreviewUrl(previewUrl);
-    setAttachError(validation.valid ? null : validation.error);
-    setIsUploadingSending(false);
+    if (isImageMime(file.type)) {
+      const previewUrl = URL.createObjectURL(file);
+      setPendingFile(file);
+      setPendingPreviewUrl(previewUrl);
+      setAttachError(validation.valid ? null : validation.error);
+      readImageDimensions(previewUrl, setPendingImageDimensions);
+    } else {
+      setPendingFile(file);
+      setPendingPreviewUrl(null);
+      setAttachError(validation.valid ? null : validation.error);
+    }
   };
 
   const handleAttachmentSend = async (caption: string) => {
@@ -344,7 +417,12 @@ export function ChatConversation({
     setIsUploadingSending(true);
     setAttachError(null);
     try {
-      await sendAttachment({ file: pendingFile, caption });
+      await sendAttachment({
+        file: pendingFile,
+        caption,
+        width: pendingImageDimensions?.width,
+        height: pendingImageDimensions?.height,
+      });
       clearPendingFile();
     } catch (err) {
       setAttachError((err as Error).message ?? "Error al subir el archivo");
@@ -379,32 +457,31 @@ export function ChatConversation({
     isAtBottomRef.current = true;
   }, [chat?.id, pendingDirectChat?.userId]);
 
-  // ResizeObserver: corrige el scroll cada vez que el contenido crece
-  // (imágenes que cargan, mensajes nuevos, etc.)
+  // ResizeObserver: corrige el scroll cuando el contenido crece (imágenes,
+  // cards async, etc.). Observa innerRef que es estable — no cambia cuando
+  // el chat cambia, a diferencia de firstElementChild que se reemplaza.
   useEffect(() => {
     const scrollEl = scrollRef.current;
-    if (!scrollEl) return;
+    const inner = innerRef.current;
+    if (!scrollEl || !inner) return;
 
     const observer = new ResizeObserver(() => {
-      if (isInitialLoadRef.current || isAtBottomRef.current) {
+      const dist = scrollEl.scrollHeight - scrollEl.scrollTop - scrollEl.clientHeight;
+      if (isInitialLoadRef.current || isAtBottomRef.current || dist < 250) {
         scrollEl.scrollTop = scrollEl.scrollHeight;
       }
     });
 
-    const inner = scrollEl.firstElementChild;
-    if (inner) observer.observe(inner);
-
+    observer.observe(inner);
     return () => observer.disconnect();
-  }, [chat?.id, pendingDirectChat?.userId]);
+  }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isLoadingMessages) return;
     if (isInitialLoadRef.current && messages.length > 0) {
       isInitialLoadRef.current = false;
-      requestAnimationFrame(() => {
-        const el = scrollRef.current;
-        if (el) el.scrollTop = el.scrollHeight;
-      });
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
     }
   }, [messages.length, isLoadingMessages]);
 
@@ -601,7 +678,13 @@ export function ChatConversation({
 
   const otherParticipantId = !isGroup
     ? chat?.participantes.find((p) => p.usuario?.id !== Number(currentUserId))
-        ?.usuario?.id
+      ?.usuario?.id
+    : undefined;
+
+  const otherParticipant = !isGroup
+    ? chat?.participantes.find(
+      (p) => p.usuario?.id !== Number(currentUserId)
+    )?.usuario
     : undefined;
 
   const isOtherOnline = usePresenceStore((s) => {
@@ -623,6 +706,28 @@ export function ChatConversation({
 
   return (
     <div ref={containerRef} className="flex h-full relative">
+      <input
+        ref={imageInputRef}
+        type="file"
+        className="sr-only"
+        accept="image/jpeg,image/png,image/webp,image/gif"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFileSelected(file);
+          e.target.value = "";
+        }}
+      />
+      <input
+        ref={documentInputRef}
+        type="file"
+        className="sr-only"
+        accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) void handleFileSelected(file);
+          e.target.value = "";
+        }}
+      />
       <div
         className={cn(
           "flex min-w-0 flex-1 flex-col",
@@ -725,71 +830,73 @@ export function ChatConversation({
           <div
             ref={scrollRef}
             onScroll={handleScroll}
-            className="absolute inset-0 space-y-2 overflow-y-auto bg-muted/5 p-4"
+            className="absolute inset-0 overflow-y-auto bg-muted/5 [overflow-anchor:none]"
           >
-            {isFetchingOlderMessages && (
-              <div className="flex justify-center py-2">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-              </div>
-            )}
-            {isLoadingMessages ? (
-              <div className="flex h-full items-center justify-center">
-                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-              </div>
-            ) : messages.length === 0 ? (
-              <div className="flex flex-col items-center gap-2 py-10 text-center">
-                <p className="text-xs text-muted-foreground">
-                  Sin mensajes aún
-                </p>
-                <p className="text-[10px] text-muted-foreground/60">
-                  Sé el primero en escribir
-                </p>
-              </div>
-            ) : (
-              messages.map((msg, i) => {
-                const prev = messages[i - 1];
-                const msgDay = new Date(msg.fecha_reg);
-                msgDay.setHours(0, 0, 0, 0);
+            <div ref={innerRef} className="space-y-2 p-4">
+              {isFetchingOlderMessages && (
+                <div className="flex justify-center py-2">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              )}
+              {isLoadingMessages ? (
+                <div className="flex h-full items-center justify-center">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                </div>
+              ) : messages.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-10 text-center">
+                  <p className="text-xs text-muted-foreground">
+                    Sin mensajes aún
+                  </p>
+                  <p className="text-[10px] text-muted-foreground/60">
+                    Sé el primero en escribir
+                  </p>
+                </div>
+              ) : (
+                messages.map((msg, i) => {
+                  const prev = messages[i - 1];
+                  const msgDay = new Date(msg.fecha_reg);
+                  msgDay.setHours(0, 0, 0, 0);
 
-                const prevDay = prev ? new Date(prev.fecha_reg) : null;
-                if (prevDay) prevDay.setHours(0, 0, 0, 0);
+                  const prevDay = prev ? new Date(prev.fecha_reg) : null;
+                  if (prevDay) prevDay.setHours(0, 0, 0, 0);
 
-                const showSeparator =
-                  !prevDay || msgDay.getTime() !== prevDay.getTime();
+                  const showSeparator =
+                    !prevDay || msgDay.getTime() !== prevDay.getTime();
 
-                return (
-                  <div
-                    key={
-                      "_tempId" in msg
-                        ? (msg as OptimisticMessage)._tempId
-                        : msg.id
-                    }
-                  >
-                    {showSeparator && <DateSeparator date={msg.fecha_reg} />}
-                    <MessageBubble
-                      message={msg}
-                      prevSenderId={prev?.remitente?.id ?? null}
-                      // onReply={exMember ? undefined : setReplyTo}
-                      isDirectChat={chat?.tipo === "DIRECT"}
-                      otherDate={showSeparator}
-                      onEdit={exMember ? undefined : handleStartEdit}
-                      onDeleteForAll={
-                        exMember ? undefined : (m) => deleteForAll.mutate(m.id)
+                  return (
+                    <div
+                      key={
+                        "_tempId" in msg
+                          ? (msg as OptimisticMessage)._tempId
+                          : msg.id
                       }
-                      onDeleteForMe={
-                        exMember ? undefined : (m) => deleteForMe.mutate(m.id)
-                      }
-                      canModerate={canModerate}
-                      onRetry={exMember ? undefined : handleRetry}
-                      // onDeleteFailed={exMember ? undefined : handleDeleteFailed}
-                      onRetryAttachment={
-                        exMember ? undefined : handleAttachmentRetry
-                      }
-                    />
-                  </div>
-                );
-              })
-            )}
+                    >
+                      {showSeparator && <DateSeparator date={msg.fecha_reg} />}
+                      <MessageBubble
+                        message={msg}
+                        prevSenderId={prev?.remitente?.id ?? null}
+                        // onReply={exMember ? undefined : setReplyTo}
+                        isDirectChat={chat?.tipo === "DIRECT"}
+                        otherDate={showSeparator}
+                        onEdit={exMember ? undefined : handleStartEdit}
+                        onDeleteForAll={
+                          exMember ? undefined : (m) => deleteForAll.mutate(m.id)
+                        }
+                        onDeleteForMe={
+                          exMember ? undefined : (m) => deleteForMe.mutate(m.id)
+                        }
+                        canModerate={canModerate}
+                        onRetry={exMember ? undefined : handleRetry}
+                        // onDeleteFailed={exMember ? undefined : handleDeleteFailed}
+                        onRetryAttachment={
+                          exMember ? undefined : handleAttachmentRetry
+                        }
+                      />
+                    </div>
+                  );
+                })
+              )}
+            </div>
           </div>
         </div>
 
@@ -836,6 +943,11 @@ export function ChatConversation({
                   onSend={handleAttachmentSend}
                   onCancel={clearPendingFile}
                 />
+              ) : isCompressing ? (
+                <div className="flex items-center gap-2.5 rounded-2xl border border-border px-4 py-3 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                  Procesando...
+                </div>
               ) : (
                 <div
                   className={cn(
@@ -845,7 +957,60 @@ export function ChatConversation({
                 >
                   {!editingMessage && (
                     <>
-                      <FilePickerButton onFileSelected={handleFileSelected} />
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                            <Paperclip className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent side="top" align="start" className="z-[9999]">
+                          <DropdownMenuLabel className="text-xs text-muted-foreground">
+                            Adjuntar
+                          </DropdownMenuLabel>
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              setTimeout(() => imageInputRef.current?.click(), 0)
+                            }
+                          >
+                            <ImageIcon className="mr-2 h-4 w-4" />
+                            Imagen
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              setTimeout(
+                                () => documentInputRef.current?.click(),
+                                0,
+                              )
+                            }
+                          >
+                            <FileText className="mr-2 h-4 w-4 shrink-0" />
+                            <div className="flex flex-col">
+                              <span>Documento</span>
+                              <span className="text-[10px] text-muted-foreground">
+                                PDF · Word · Excel
+                              </span>
+                            </div>
+                          </DropdownMenuItem>
+                          {!isGroup && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onSelect={() =>
+                                  navigate(
+                                    "/dashboard/transfers/request/new",
+                                    {
+                                      state: { destinatario: otherParticipant },
+                                    },
+                                  )
+                                }
+                              >
+                                <PackagePlus className="mr-2 h-4 w-4" />
+                                Solicitar transferencia
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                       {/* Vincular documento (comentado) */}
                     </>
                   )}

--- a/src/modules/messaging/components/ChatFloatingWindow.tsx
+++ b/src/modules/messaging/components/ChatFloatingWindow.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { DEFAULT_FLOATING_SIZE } from "../stores/ChatUiStore";
 import {
   Maximize2,
   Minimize2,
@@ -37,6 +38,10 @@ export function ChatFloatingWindow() {
     setViewMode,
     setFloatingPos,
     setFloatingSize,
+    isMaximized,
+    setIsMaximized,
+    preMaximizeLayout,
+    setPreMaximizeLayout,
   } = useChatUIStore();
 
   const pendingDirectChat = useChatStore((s) => s.pendingDirectChat);
@@ -45,22 +50,18 @@ export function ChatFloatingWindow() {
   const { isLoading: isLoadingChats } = useChats();
 
   const [isDragging, setIsDragging] = useState(false);
-  const [isMaximized, setIsMaximized] = useState(false);
-  const [prevLayout, setPrevLayout] = useState<{
-    pos: typeof floatingPos;
-    size: typeof floatingSize;
-  } | null>(null);
 
   const dragOffsetRef = useRef({ x: 0, y: 0 });
   const windowRef = useRef<HTMLDivElement>(null);
 
-  // ¿Hay espacio suficiente para mostrar las dos columnas?
-  const [isTwoColumn, setIsTwoColumn] = useState<boolean>(false);
+  // Two-column layout follows maximize state
+  const isTwoColumn = isMaximized;
 
   // ── Drag ──────────────────────────────────────────────────────────────────
   const handleDragStart = useCallback(
     (e: React.MouseEvent) => {
       if (isMaximized) return;
+      e.preventDefault();
       dragOffsetRef.current = {
         x: e.clientX - floatingPos.x,
         y: e.clientY - floatingPos.y,
@@ -72,6 +73,7 @@ export function ChatFloatingWindow() {
 
   useEffect(() => {
     if (!isDragging) return;
+    document.body.style.userSelect = "none";
     const onMove = (e: MouseEvent) => {
       const x = Math.max(
         0,
@@ -90,6 +92,7 @@ export function ChatFloatingWindow() {
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
     return () => {
+      document.body.style.userSelect = "";
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
@@ -98,7 +101,9 @@ export function ChatFloatingWindow() {
   // ── Resize ─────────────────────────────────────────────────────────────────
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
+      e.preventDefault();
       e.stopPropagation();
+      document.body.style.userSelect = "none";
       const startX = e.clientX;
       const startY = e.clientY;
       const startW = floatingSize.w;
@@ -115,6 +120,7 @@ export function ChatFloatingWindow() {
         setFloatingSize({ w: newW, h: newH });
       };
       const onUp = () => {
+        document.body.style.userSelect = "";
         window.removeEventListener("mousemove", onMove);
         window.removeEventListener("mouseup", onUp);
       };
@@ -127,21 +133,23 @@ export function ChatFloatingWindow() {
   // ── Maximize toggle ────────────────────────────────────────────────────────
   const toggleMaximize = () => {
     if (isMaximized) {
-      if (prevLayout) {
-        setFloatingPos(prevLayout.pos);
-        setFloatingSize(prevLayout.size);
-      }
+      const restoreSize = preMaximizeLayout?.size ?? DEFAULT_FLOATING_SIZE;
+      const restorePos = preMaximizeLayout?.pos ?? {
+        x: window.innerWidth - restoreSize.w - 24,
+        y: window.innerHeight - restoreSize.h - 24,
+      };
+      setFloatingPos(restorePos);
+      setFloatingSize(restoreSize);
+      setPreMaximizeLayout(null);
       setIsMaximized(false);
-      setIsTwoColumn(false);
     } else {
-      setPrevLayout({ pos: floatingPos, size: floatingSize });
+      setPreMaximizeLayout({ pos: floatingPos, size: floatingSize });
       setFloatingPos({ x: 60, y: 20 });
       setFloatingSize({
         w: window.innerWidth - 120,
         h: window.innerHeight - 80,
       });
       setIsMaximized(true);
-      setIsTwoColumn(true);
     }
   };
 

--- a/src/modules/messaging/components/MessageBubble.tsx
+++ b/src/modules/messaging/components/MessageBubble.tsx
@@ -35,6 +35,7 @@ import authSDK from "@/services/sdk-simple-auth";
 import { Button } from "@/components/atoms/button";
 import { Avatar, AvatarFallback } from "@/components/atoms/avatar";
 import { AttachmentMessage } from "./AttachmentMessage";
+import { TransferRequestCard } from "./TransferRequestCard";
 import { getInitials } from "../utils/chatUtils";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -426,12 +427,20 @@ export function MessageBubble({
             </p>
           )}
 
-          {/* Reference badge */}
+          {/* Reference badge / transfer request card */}
           {message.referencia_tipo && message.referencia_id && (
-            <ReferenceBadge
-              tipo={message.referencia_tipo}
-              id={message.referencia_id}
-            />
+            message.referencia_tipo === "transfer_request" ? (
+              <TransferRequestCard
+                requestId={message.referencia_id}
+                currentUserId={currentUserId}
+                isMine={isMine}
+              />
+            ) : (
+              <ReferenceBadge
+                tipo={message.referencia_tipo}
+                id={message.referencia_id}
+              />
+            )
           )}
 
           {/* Timestamp + status + badge "editado" */}

--- a/src/modules/messaging/components/MessageBubble.tsx
+++ b/src/modules/messaging/components/MessageBubble.tsx
@@ -111,14 +111,7 @@ function MessageStatus({
     return <span className="text-[9px] opacity-60">cola</span>;
   if (status === "failed") {
     return (
-      <button
-        onClick={() => isOptimistic && onRetry?.(message as OptimisticMessage)}
-        className="flex items-center gap-0.5 text-[9px] text-destructive hover:text-destructive/80 transition-colors"
-        title="Toca para reintentar"
-      >
-        <span>!</span>
-        <span className="underline">reintentar</span>
-      </button>
+      <span className="text-[10px] font-bold text-destructive" title="Error al enviar">!</span>
     );
   }
   return <CheckCheck className="h-3 w-3 text-blue-400" />;
@@ -293,12 +286,12 @@ export function MessageBubble({
           </span>
         )}
 
-        {/* Hover actions */}
+        {/* Hover actions — positioned beside the bubble (Telegram-style) */}
         <div
           className={cn(
-            "absolute -top-6 z-10 flex items-center gap-0.5 rounded-lg border border-border/50 bg-card p-0.5 shadow-md",
-            "opacity-0 group-hover:opacity-100 transition-opacity",
-            isMine ? "right-0" : "left-0"
+            "absolute top-1/2 -translate-y-1/2 z-10 flex items-center gap-0.5 rounded-lg border border-border/50 bg-card p-0.5 shadow-md transition-opacity",
+            isMine ? "right-[calc(100%+6px)]" : "left-[calc(100%+6px)]",
+            menuOpen ? "opacity-100" : "opacity-0 group-hover:opacity-100",
           )}
         >
           {onReply && (
@@ -388,18 +381,19 @@ export function MessageBubble({
         {/* Bubble */}
         <div
           className={cn(
-            "rounded-2xl text-sm break-words",
+            "rounded-2xl text-sm break-words transition-shadow",
             message.tipo === "FILE" && message.adjuntos?.[0]?.es_imagen
-              ? "overflow-hidden px-1.5 pt-0.5 pb-1"
+              ? "overflow-hidden px-1.5 pt-0.5 pb-1 max-w-[340px]"
               : message.tipo === "FILE"
                 ? "px-1.5 pt-0.5 pb-1"
                 : "px-3 py-1",
             isMine
-              ? "bg-primary text-primary-foreground rounded-tr-xs"
-              : "bg-secondary text-foreground rounded-tl-xs",
+              ? "bg-primary text-primary-foreground rounded-tr-xs shadow-[0_4px_16px_rgba(0,0,0,0.2)] ring-1 ring-black/[0.07] group-hover:ring-2 group-hover:ring-white/30"
+              : "bg-secondary text-foreground rounded-tl-xs shadow-[0_1px_3px_rgba(0,0,0,0.07),0_4px_14px_rgba(0,0,0,0.05)] group-hover:ring-2 group-hover:ring-primary/25",
             isGrouped && !isMine && "rounded-tl-2xl",
             isGrouped && isMine && "rounded-tr-2xl",
-            status === "failed" && "opacity-60 ring-1 ring-destructive/40"
+            status === "failed" && "opacity-60 ring-1 ring-destructive/40",
+            menuOpen && (isMine ? "ring-2 ring-white/40" : "ring-2 ring-primary/40"),
           )}
         >
           {/* Adjuntos */}
@@ -477,6 +471,7 @@ export function MessageBubble({
             )}
           </div>
         </div>
+
       </div>
     </div>
   );

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -6,8 +6,10 @@
  * - Shows product summary, branch-to-branch direction, estado badge
  * - Action buttons ("Importar" / "Enviar directo") are visible ONLY to the
  *   destinatario (currentUserId === request.usuario_destinatario_id)
- * - Terminal estados (FULFILLED, IMPORTED, CANCELLED) hide action buttons
- * - "Enviar directo" shows a confirm modal, then a result modal
+ * - Terminal estados (FULFILLED, PARTIAL, CANCELLED) hide action buttons
+ * - "imported" is transitional: shows "Retomar importación" + "Enviar directo"
+ * - "in_progress": transfer created but not yet confirmed — shows link
+ * - "Enviar directo" shows a confirm modal, then a result modal with navigation
  */
 
 import { useState } from "react";
@@ -41,14 +43,19 @@ const ESTADO_CONFIG: Record<
   TransferRequestEstado,
   { label: string; variant: "warning" | "success" | "accent" | "info" | "danger" }
 > = {
-  pending:   { label: "Pendiente",  variant: "warning" },
-  fulfilled: { label: "Completado", variant: "success" },
-  partial:   { label: "Parcial",    variant: "accent" },
-  imported:  { label: "Importado",  variant: "info" },
-  cancelled: { label: "Cancelado",  variant: "danger" },
+  pending:     { label: "Pendiente",   variant: "warning" },
+  fulfilled:   { label: "Completado",  variant: "success" },
+  partial:     { label: "Parcial",     variant: "accent" },
+  imported:    { label: "Importado",   variant: "info" },
+  in_progress: { label: "En proceso",  variant: "info" },
+  cancelled:   { label: "Cancelado",   variant: "danger" },
 };
 
-const TERMINAL_ESTADOS: TransferRequestEstado[] = ["fulfilled", "imported", "cancelled"];
+// States where the recipient can no longer take direct action — show transfer link instead
+const TERMINAL_ESTADOS: TransferRequestEstado[] = ["fulfilled", "partial", "cancelled", "in_progress"];
+
+// States where the recipient still needs to act
+const ACTIONABLE_ESTADOS: TransferRequestEstado[] = ["pending", "imported"];
 
 function EstadoBadge({ estado }: { estado: TransferRequestEstado }) {
   const config = ESTADO_CONFIG[estado] ?? { label: estado, variant: "warning" as const };
@@ -66,10 +73,11 @@ function EstadoBadge({ estado }: { estado: TransferRequestEstado }) {
 interface FulfillResultModalProps {
   open: boolean;
   onClose: () => void;
+  onGoToTransfer?: () => void;
   result: FulfillDirectResult;
 }
 
-function FulfillResultModal({ open, onClose, result }: FulfillResultModalProps) {
+function FulfillResultModal({ open, onClose, onGoToTransfer, result }: FulfillResultModalProps) {
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
       <DialogContent className="max-w-md z-[9999]">
@@ -139,10 +147,16 @@ function FulfillResultModal({ open, onClose, result }: FulfillResultModalProps) 
           )}
         </div>
 
-        <DialogFooter>
-          <Button size="sm" onClick={onClose}>
+        <DialogFooter className="gap-2">
+          <Button size="sm" variant="outline" onClick={onClose}>
             Cerrar
           </Button>
+          {onGoToTransfer && result.transfer_id && (
+            <Button size="sm" onClick={onGoToTransfer} className="gap-1.5">
+              <ExternalLink className="h-3.5 w-3.5" />
+              Ir a confirmar envío
+            </Button>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -245,7 +259,10 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
   const isRecipient =
     !!request && String(request.usuario_destinatario_id) === String(currentUserId);
   const isTerminal = !!request && TERMINAL_ESTADOS.includes(request.estado);
-  const showActions = isRecipient && !isTerminal;
+  const isActionable = !!request && ACTIONABLE_ESTADOS.includes(request.estado);
+  const isImportedState = request?.estado === "imported";
+  // Recipient still needs to act (pending or stuck at imported with no transfer yet)
+  const showActions = isRecipient && isActionable;
 
   // ── Handlers ──────────────────────────────────────────────────────────────
   const handleFulfillConfirm = async () => {
@@ -391,14 +408,23 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
           </ul>
         )}
 
-        {/* Terminal estado indicator + optional transfer link */}
+        {/* Non-actionable: show transfer link or processed message */}
         {isTerminal && (
           <div className="space-y-1.5">
             <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-              <CheckCircle2 className="h-3 w-3 shrink-0" />
-              <span>Esta solicitud ya fue procesada</span>
+              {request.estado === "in_progress" ? (
+                <>
+                  <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                  <span>Transferencia creada, esperando confirmación de envío</span>
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-3 w-3 shrink-0" />
+                  <span>Esta solicitud ya fue procesada</span>
+                </>
+              )}
             </div>
-            {request.product_transfer_id ? (
+            {request.product_transfer_id != null ? (
               <Button
                 size="sm"
                 variant="secondary"
@@ -408,7 +434,7 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
                 <ExternalLink className="h-3 w-3" />
                 Ver transferencia
               </Button>
-            ) : (
+            ) : request.estado !== "cancelled" ? (
               <Button
                 size="sm"
                 variant="ghost"
@@ -418,11 +444,11 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
                 <ExternalLink className="h-3 w-3" />
                 Ver transferencias
               </Button>
-            )}
+            ) : null}
           </div>
         )}
 
-        {/* Action buttons — only for recipient on non-terminal estados */}
+        {/* Action buttons — recipient on actionable states (pending or imported) */}
         {showActions && (
           <div className="flex gap-1.5 pt-0.5">
             {canImport && (
@@ -435,6 +461,8 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
               >
                 {importMutation.isPending ? (
                   <Loader2 className="h-3 w-3 animate-spin" />
+                ) : isImportedState ? (
+                  "Retomar importación"
                 ) : (
                   "Importar"
                 )}
@@ -449,7 +477,7 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
                 onClick={() => setConfirmFulfillOpen(true)}
               >
                 {fulfill.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : (
                   "Enviar directo"
                 )}
@@ -458,8 +486,8 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
           </div>
         )}
 
-        {/* Permission-based notice when recipient but no permissions */}
-        {isRecipient && !isTerminal && !canImport && !canFulfill && (
+        {/* Permission-based notice when recipient but no permissions and still actionable */}
+        {isRecipient && isActionable && !canImport && !canFulfill && (
           <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
             <XCircle className="h-3 w-3 shrink-0 text-muted-foreground/60" />
             <span>Sin permisos para actuar sobre esta solicitud</span>
@@ -480,6 +508,15 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
         <FulfillResultModal
           open={!!fulfillResult}
           onClose={() => setFulfillResult(null)}
+          onGoToTransfer={
+            fulfillResult.transfer_id
+              ? () => {
+                  const tid = fulfillResult.transfer_id;
+                  setFulfillResult(null);
+                  navigate(`/dashboard/transfers/${tid}`);
+                }
+              : undefined
+          }
           result={fulfillResult}
         />
       )}

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -13,6 +13,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
 import { Loader2, ArrowRight, Package, CheckCircle2, XCircle } from "lucide-react";
+import { showErrorToast, showWarningToast } from "@/hooks/use-toast-enhanced";
 import { Button } from "@/components/atoms/button";
 import { Badge } from "@/components/atoms/badge";
 import { Skeleton } from "@/components/atoms/skeleton";
@@ -40,14 +41,14 @@ const ESTADO_CONFIG: Record<
   TransferRequestEstado,
   { label: string; variant: "warning" | "success" | "accent" | "info" | "danger" }
 > = {
-  PENDING: { label: "Pendiente", variant: "warning" },
-  FULFILLED: { label: "Completado", variant: "success" },
-  PARTIAL: { label: "Parcial", variant: "accent" },
-  IMPORTED: { label: "Importado", variant: "info" },
-  CANCELLED: { label: "Cancelado", variant: "danger" },
+  pending:   { label: "Pendiente",  variant: "warning" },
+  fulfilled: { label: "Completado", variant: "success" },
+  partial:   { label: "Parcial",    variant: "accent" },
+  imported:  { label: "Importado",  variant: "info" },
+  cancelled: { label: "Cancelado",  variant: "danger" },
 };
 
-const TERMINAL_ESTADOS: TransferRequestEstado[] = ["FULFILLED", "IMPORTED", "CANCELLED"];
+const TERMINAL_ESTADOS: TransferRequestEstado[] = ["fulfilled", "imported", "cancelled"];
 
 function EstadoBadge({ estado }: { estado: TransferRequestEstado }) {
   const config = ESTADO_CONFIG[estado] ?? { label: estado, variant: "warning" as const };
@@ -71,10 +72,10 @@ interface FulfillResultModalProps {
 function FulfillResultModal({ open, onClose, result }: FulfillResultModalProps) {
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-w-md z-[9999]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {result.request_estado === "FULFILLED" ? (
+            {result.request_estado === "fulfilled" ? (
               <CheckCircle2 className="h-4 w-4 text-emerald-500" />
             ) : (
               <Package className="h-4 w-4 text-amber-500" />
@@ -167,7 +168,7 @@ function ConfirmFulfillModal({
 }: ConfirmFulfillModalProps) {
   return (
     <Dialog open={open} onOpenChange={(v) => !v && !isPending && onClose()}>
-      <DialogContent className="max-w-sm">
+      <DialogContent className="max-w-sm z-[9999]">
         <DialogHeader>
           <DialogTitle>Enviar directo</DialogTitle>
           <DialogDescription>
@@ -260,11 +261,39 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
   const handleImport = async () => {
     try {
       const result = await importMutation.mutateAsync();
+
+      const withStock = result.items.filter((i) => i.lots && i.lots.length > 0);
+      const withoutStock = result.items.filter((i) => !i.lots || i.lots.length === 0);
+
+      if (withStock.length === 0) {
+        showErrorToast({
+          title: "Sin stock disponible",
+          description: "Ningún producto de la solicitud tiene stock en tu sucursal. No se puede crear la transferencia.",
+          duration: 5000,
+        });
+        return;
+      }
+
+      if (withoutStock.length > 0) {
+        const names = withoutStock
+          .map((i) => i.product?.descripcion ?? `Producto #${i.producto_id}`)
+          .join(", ");
+        showWarningToast({
+          title: `${withoutStock.length} producto${withoutStock.length > 1 ? "s" : ""} sin stock`,
+          description: `Se omitirán: ${names}`,
+          duration: 6000,
+        });
+      }
+
       navigate("/dashboard/create-transfer", {
         state: { transferRequestPrefill: result },
       });
     } catch {
-      // error handled by caller or toast
+      showErrorToast({
+        title: "Error al importar",
+        description: "No se pudo importar la solicitud. Intentá de nuevo.",
+        duration: 4000,
+      });
     }
   };
 

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -35,6 +35,7 @@ import { useTransferRequestById } from "@/modules/transfers/hooks/useTransferReq
 import { useImportTransferRequest } from "@/modules/transfers/hooks/useImportTransferRequest";
 import { useFulfillTransferRequest } from "@/modules/transfers/hooks/useFulfillTransferRequest";
 import { transferRequestService } from "@/modules/transfers/services/transferRequestService";
+import { useChatUIStore } from "@/modules/messaging/stores/ChatUiStore";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ESTADO BADGE
@@ -311,12 +312,12 @@ function ConfirmFulfillModal({
 interface Props {
   requestId: number;
   currentUserId: string | number | undefined;
-  /** Whether the bubble itself is mine (affects subtle styling) */
   isMine?: boolean;
 }
 
 export function TransferRequestCard({ requestId, currentUserId, isMine = false }: Props) {
   const navigate = useNavigate();
+  const closeChat = useChatUIStore((s) => s.close);
 
   // ── Data ──────────────────────────────────────────────────────────────────
   const { data: request, isLoading } = useTransferRequestById(requestId);
@@ -388,6 +389,7 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
         });
       }
 
+      closeChat();
       navigate("/dashboard/create-transfer", {
         state: { transferRequestPrefill: result },
       });
@@ -403,33 +405,38 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
   // ── Loading skeleton ──────────────────────────────────────────────────────
   if (isLoading) {
     return (
-      <div className="mt-1.5 rounded-xl border border-border/50 bg-card/50 p-3 space-y-2 min-w-[220px]">
+      <div className={cn(
+        "mt-2 rounded-xl border w-full overflow-hidden px-3 py-2.5 space-y-2",
+        isMine
+          ? "border-border/40 bg-muted shadow-[0_4px_16px_rgba(0,0,0,0.2)] ring-1 ring-black/[0.07]"
+          : "border-border bg-card shadow-md"
+      )}>
         <Skeleton className="h-3 w-2/3" />
-        <Skeleton className="h-3 w-1/2" />
-        <Skeleton className="h-3 w-3/4" />
+        <Skeleton className="h-2.5 w-1/2" />
+        <Skeleton className="h-2.5 w-3/4" />
       </div>
     );
   }
 
   if (!request) return null;
 
-  const itemCount = request.items.length;
+  const visibleItems = request.items.slice(0, 3);
 
   return (
     <>
       <div
         className={cn(
-          "mt-1.5 rounded-xl border px-3 py-2.5 min-w-[220px] max-w-[300px] space-y-2",
+          "mt-2 rounded-xl border w-full overflow-hidden px-3 py-2.5 space-y-2",
           isMine
-            ? "border-background/15 bg-background/20"
-            : "border-border/50 bg-card/50"
+            ? "border-border/40 bg-muted shadow-[0_4px_16px_rgba(0,0,0,0.2)] ring-1 ring-black/[0.07]"
+            : "border-border bg-card shadow-md"
         )}
       >
-        {/* Header row: icon + title + estado */}
+        {/* Header: icono + título + badge */}
         <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-1.5">
-            <Package className="h-3.5 w-3.5 text-primary/70 shrink-0" />
-            <span className={cn("text-[11px] font-semibold", isMine ? "text-primary-foreground" : "text-foreground")}>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <Package className="h-3.5 w-3.5 shrink-0 text-primary/70" />
+            <span className="text-[11px] font-semibold truncate text-foreground">
               Solicitud de transferencia
             </span>
           </div>
@@ -437,83 +444,58 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
         </div>
 
         {/* Branch direction */}
-        <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
-          <span className="truncate max-w-[80px]">{request.sucursal_solicitante_nombre}</span>
-          <ArrowRight className="h-3 w-3 shrink-0" />
-          <span className="truncate max-w-[80px]">{request.sucursal_destinataria_nombre}</span>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span className="truncate">{request.sucursal_solicitante_nombre}</span>
+          <ArrowRight className="h-3 w-3 shrink-0 flex-none" />
+          <span className="truncate">{request.sucursal_destinataria_nombre}</span>
         </div>
 
-        {/* Product summary */}
-        <div
-          className={cn(
-            "text-[11px]",
-            isMine ? "text-primary-foreground/80" : "text-muted-foreground"
-          )}
-        >
-          {itemCount === 1
-            ? `1 producto solicitado`
-            : `${itemCount} productos solicitados`}
-        </div>
-
-        {/* Product list (up to 3 items shown) */}
-        {request.items.length > 0 && (
-          <ul className="space-y-0.5">
-            {request.items.slice(0, 3).map((item) => (
-              <li
-                key={item.id}
-                className="flex items-center justify-between text-[10px]"
-              >
-                <span
-                  className={cn(
-                    "truncate",
-                    isMine ? "text-primary-foreground/70" : "text-muted-foreground"
-                  )}
-                >
-                  {item.producto_descripcion}
-                </span>
-                <span
-                  className={cn(
-                    "ml-2 shrink-0 font-semibold",
-                    isMine ? "text-primary-foreground" : "text-foreground"
-                  )}
-                >
-                  ×{item.cantidad_solicitada}
-                </span>
-              </li>
+        {/* Item list con separadores gradient entre items */}
+        {visibleItems.length > 0 && (
+          <div>
+            {visibleItems.map((item, idx) => (
+              <div key={item.id}>
+                <div className="flex items-center justify-between text-[10px] py-1">
+                  <span className="truncate mr-2 text-muted-foreground">
+                    {item.producto_descripcion}
+                  </span>
+                  <span className="shrink-0 font-semibold tabular-nums text-foreground">
+                    ×{item.cantidad_solicitada}
+                  </span>
+                </div>
+                {idx < visibleItems.length - 1 && (
+                  <div className="h-px bg-gradient-to-r from-transparent via-border to-transparent" />
+                )}
+              </div>
             ))}
             {request.items.length > 3 && (
-              <li
-                className={cn(
-                  "text-[10px] italic",
-                  isMine ? "text-primary-foreground/50" : "text-muted-foreground/70"
-                )}
-              >
+              <p className="text-[10px] italic text-muted-foreground/70 pt-1">
                 +{request.items.length - 3} más…
-              </li>
+              </p>
             )}
-          </ul>
+          </div>
         )}
 
-        {/* Non-actionable: show transfer link or processed message */}
+        {/* Estado terminal: mensaje + link */}
         {isTerminal && (
-          <div className="space-y-1.5">
+          <div className="space-y-1.5 pt-0.5">
             <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
               {request.estado === "in_progress" ? (
                 <>
                   <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
-                  <span>Transferencia creada, esperando confirmación de envío</span>
+                  <span>Esperando confirmación de envío</span>
                 </>
               ) : (
                 <>
                   <CheckCircle2 className="h-3 w-3 shrink-0" />
-                  <span>Esta solicitud ya fue procesada</span>
+                  <span>Solicitud ya procesada</span>
                 </>
               )}
             </div>
             {request.product_transfer_id != null ? (
               <Button
                 size="sm"
-                variant="secondary"
+                variant="link"
                 className="h-7 w-full text-[11px] px-2 gap-1.5"
                 onClick={() => navigate(`/dashboard/transfers/${request.product_transfer_id}`)}
               >
@@ -534,7 +516,7 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
           </div>
         )}
 
-        {/* Action buttons — recipient on actionable states (pending or imported) */}
+        {/* Botones de acción */}
         {showActions && (
           <div className="flex gap-1.5 pt-0.5">
             {canImport && (
@@ -548,16 +530,16 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
                 {importMutation.isPending ? (
                   <Loader2 className="h-3 w-3 animate-spin" />
                 ) : isImportedState ? (
-                  "Retomar importación"
+                  "Retomar"
                 ) : (
                   "Importar"
                 )}
               </Button>
             )}
-
             {canFulfill && (
               <Button
                 size="sm"
+                variant="default"
                 className="h-7 flex-1 text-[11px] px-2"
                 disabled={fulfill.isPending || isLoadingPreview}
                 onClick={() => {
@@ -583,11 +565,11 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
           </div>
         )}
 
-        {/* Permission-based notice when recipient but no permissions and still actionable */}
+        {/* Sin permisos */}
         {isRecipient && isActionable && !canImport && !canFulfill && (
           <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-            <XCircle className="h-3 w-3 shrink-0 text-muted-foreground/60" />
-            <span>Sin permisos para actuar sobre esta solicitud</span>
+            <XCircle className="h-3 w-3 shrink-0 opacity-60" />
+            <span>Sin permisos para actuar</span>
           </div>
         )}
       </div>

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -1,0 +1,436 @@
+/**
+ * TransferRequestCard
+ *
+ * Renders inside MessageBubble when message.referencia_tipo === "transfer_request".
+ * - Fetches full request details via useTransferRequestById
+ * - Shows product summary, branch-to-branch direction, estado badge
+ * - Action buttons ("Importar" / "Enviar directo") are visible ONLY to the
+ *   destinatario (currentUserId === request.usuario_destinatario_id)
+ * - Terminal estados (FULFILLED, IMPORTED, CANCELLED) hide action buttons
+ * - "Enviar directo" shows a confirm modal, then a result modal
+ */
+
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { Loader2, ArrowRight, Package, CheckCircle2, XCircle } from "lucide-react";
+import { Button } from "@/components/atoms/button";
+import { Badge } from "@/components/atoms/badge";
+import { Skeleton } from "@/components/atoms/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/atoms/dialog";
+import { cn } from "@/lib/utils";
+import { PERMISSIONS } from "@/lib/permissions";
+import { usePermissionCheck } from "@/hooks/usePermissionCheck";
+import type { TransferRequestEstado, FulfillDirectResult } from "@/modules/transfers/types/transferRequest.types";
+import { useTransferRequestById } from "@/modules/transfers/hooks/useTransferRequestById";
+import { useImportTransferRequest } from "@/modules/transfers/hooks/useImportTransferRequest";
+import { useFulfillTransferRequest } from "@/modules/transfers/hooks/useFulfillTransferRequest";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ESTADO BADGE
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ESTADO_CONFIG: Record<
+  TransferRequestEstado,
+  { label: string; variant: "warning" | "success" | "accent" | "info" | "danger" }
+> = {
+  PENDING: { label: "Pendiente", variant: "warning" },
+  FULFILLED: { label: "Completado", variant: "success" },
+  PARTIAL: { label: "Parcial", variant: "accent" },
+  IMPORTED: { label: "Importado", variant: "info" },
+  CANCELLED: { label: "Cancelado", variant: "danger" },
+};
+
+const TERMINAL_ESTADOS: TransferRequestEstado[] = ["FULFILLED", "IMPORTED", "CANCELLED"];
+
+function EstadoBadge({ estado }: { estado: TransferRequestEstado }) {
+  const config = ESTADO_CONFIG[estado] ?? { label: estado, variant: "warning" as const };
+  return (
+    <Badge variant={config.variant} className="text-[10px] px-1.5 py-0">
+      {config.label}
+    </Badge>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FULFILL RESULT MODAL
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FulfillResultModalProps {
+  open: boolean;
+  onClose: () => void;
+  result: FulfillDirectResult;
+}
+
+function FulfillResultModal({ open, onClose, result }: FulfillResultModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {result.request_estado === "FULFILLED" ? (
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+            ) : (
+              <Package className="h-4 w-4 text-amber-500" />
+            )}
+            Resultado del envío
+          </DialogTitle>
+          <DialogDescription>
+            Estado:{" "}
+            <EstadoBadge estado={result.request_estado} />
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 max-h-64 overflow-y-auto">
+          {result.fulfilled_items.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-emerald-600 dark:text-emerald-400 mb-1.5">
+                Despachados ({result.fulfilled_items.length})
+              </p>
+              <div className="space-y-1">
+                {result.fulfilled_items.map((item) => (
+                  <div
+                    key={item.producto_id}
+                    className="flex items-center justify-between rounded-lg bg-emerald-50 dark:bg-emerald-500/10 px-2.5 py-1.5 text-xs"
+                  >
+                    <span className="text-foreground">{item.producto_descripcion}</span>
+                    <span className="font-semibold text-emerald-700 dark:text-emerald-300 ml-2">
+                      ×{item.cantidad}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {result.skipped_items.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-amber-600 dark:text-amber-400 mb-1.5">
+                No despachados ({result.skipped_items.length})
+              </p>
+              <div className="space-y-1">
+                {result.skipped_items.map((item) => (
+                  <div
+                    key={item.producto_id}
+                    className="flex items-center justify-between rounded-lg bg-amber-50 dark:bg-amber-500/10 px-2.5 py-1.5 text-xs"
+                  >
+                    <div>
+                      <span className="text-foreground">{item.producto_descripcion}</span>
+                      <span className="block text-[10px] text-muted-foreground">
+                        {item.reason === "NO_STOCK" || item.reason === "INSUFFICIENT_STOCK"
+                          ? "Sin stock disponible"
+                          : "Producto inactivo"}
+                      </span>
+                    </div>
+                    <span className="font-semibold text-amber-700 dark:text-amber-300 ml-2">
+                      ×{item.cantidad_solicitada}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button size="sm" onClick={onClose}>
+            Cerrar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CONFIRM FULFILL MODAL
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ConfirmFulfillModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+function ConfirmFulfillModal({
+  open,
+  onClose,
+  onConfirm,
+  isPending,
+}: ConfirmFulfillModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && !isPending && onClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Enviar directo</DialogTitle>
+          <DialogDescription>
+            Se creará una transferencia con los productos disponibles en tu
+            sucursal. Los productos sin stock serán omitidos. Esta acción no
+            se puede deshacer.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClose}
+            disabled={isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            size="sm"
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin mr-1.5" />
+                Enviando…
+              </>
+            ) : (
+              "Confirmar envío"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MAIN COMPONENT
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Props {
+  requestId: number;
+  currentUserId: string | number | undefined;
+  /** Whether the bubble itself is mine (affects subtle styling) */
+  isMine?: boolean;
+}
+
+export function TransferRequestCard({ requestId, currentUserId, isMine = false }: Props) {
+  const navigate = useNavigate();
+
+  // ── Data ──────────────────────────────────────────────────────────────────
+  const { data: request, isLoading } = useTransferRequestById(requestId);
+
+  // ── Permission checks (always called — hooks must not be conditional) ────
+  const { isAuthorized: canFulfill } = usePermissionCheck({
+    permission: PERMISSIONS.TRA.REQUEST_FULFILL,
+    roles: ["Super Admin", "Administrador", "Vendedor"],
+  });
+  const { isAuthorized: canImport } = usePermissionCheck({
+    permission: PERMISSIONS.TRA.REQUEST_IMPORT,
+    roles: ["Super Admin", "Administrador", "Vendedor"],
+  });
+
+  // ── Mutations ─────────────────────────────────────────────────────────────
+  const fulfill = useFulfillTransferRequest(requestId);
+  const importMutation = useImportTransferRequest(requestId);
+
+  // ── Modal states ──────────────────────────────────────────────────────────
+  const [confirmFulfillOpen, setConfirmFulfillOpen] = useState(false);
+  const [fulfillResult, setFulfillResult] = useState<FulfillDirectResult | null>(null);
+
+  // ── Derived state ─────────────────────────────────────────────────────────
+  const isRecipient =
+    !!request && String(request.usuario_destinatario_id) === String(currentUserId);
+  const isTerminal = !!request && TERMINAL_ESTADOS.includes(request.estado);
+  const showActions = isRecipient && !isTerminal;
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+  const handleFulfillConfirm = async () => {
+    try {
+      const result = await fulfill.mutateAsync();
+      setConfirmFulfillOpen(false);
+      setFulfillResult(result);
+    } catch {
+      setConfirmFulfillOpen(false);
+    }
+  };
+
+  const handleImport = async () => {
+    try {
+      const result = await importMutation.mutateAsync();
+      navigate("/dashboard/create-transfer", {
+        state: { transferRequestPrefill: result },
+      });
+    } catch {
+      // error handled by caller or toast
+    }
+  };
+
+  // ── Loading skeleton ──────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div className="mt-1.5 rounded-xl border border-border/50 bg-card/50 p-3 space-y-2 min-w-[220px]">
+        <Skeleton className="h-3 w-2/3" />
+        <Skeleton className="h-3 w-1/2" />
+        <Skeleton className="h-3 w-3/4" />
+      </div>
+    );
+  }
+
+  if (!request) return null;
+
+  const itemCount = request.items.length;
+
+  return (
+    <>
+      <div
+        className={cn(
+          "mt-1.5 rounded-xl border px-3 py-2.5 min-w-[220px] max-w-[300px] space-y-2",
+          isMine
+            ? "border-background/15 bg-background/20"
+            : "border-border/50 bg-card/50"
+        )}
+      >
+        {/* Header row: icon + title + estado */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <Package className="h-3.5 w-3.5 text-primary/70 shrink-0" />
+            <span className={cn("text-[11px] font-semibold", isMine ? "text-primary-foreground" : "text-foreground")}>
+              Solicitud de transferencia
+            </span>
+          </div>
+          <EstadoBadge estado={request.estado} />
+        </div>
+
+        {/* Branch direction */}
+        <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+          <span className="truncate max-w-[80px]">{request.sucursal_solicitante_nombre}</span>
+          <ArrowRight className="h-3 w-3 shrink-0" />
+          <span className="truncate max-w-[80px]">{request.sucursal_destinataria_nombre}</span>
+        </div>
+
+        {/* Product summary */}
+        <div
+          className={cn(
+            "text-[11px]",
+            isMine ? "text-primary-foreground/80" : "text-muted-foreground"
+          )}
+        >
+          {itemCount === 1
+            ? `1 producto solicitado`
+            : `${itemCount} productos solicitados`}
+        </div>
+
+        {/* Product list (up to 3 items shown) */}
+        {request.items.length > 0 && (
+          <ul className="space-y-0.5">
+            {request.items.slice(0, 3).map((item) => (
+              <li
+                key={item.id}
+                className="flex items-center justify-between text-[10px]"
+              >
+                <span
+                  className={cn(
+                    "truncate",
+                    isMine ? "text-primary-foreground/70" : "text-muted-foreground"
+                  )}
+                >
+                  {item.producto_descripcion}
+                </span>
+                <span
+                  className={cn(
+                    "ml-2 shrink-0 font-semibold",
+                    isMine ? "text-primary-foreground" : "text-foreground"
+                  )}
+                >
+                  ×{item.cantidad_solicitada}
+                </span>
+              </li>
+            ))}
+            {request.items.length > 3 && (
+              <li
+                className={cn(
+                  "text-[10px] italic",
+                  isMine ? "text-primary-foreground/50" : "text-muted-foreground/70"
+                )}
+              >
+                +{request.items.length - 3} más…
+              </li>
+            )}
+          </ul>
+        )}
+
+        {/* Terminal estado indicator (no buttons) */}
+        {isTerminal && (
+          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <CheckCircle2 className="h-3 w-3 shrink-0" />
+            <span>Esta solicitud ya fue procesada</span>
+          </div>
+        )}
+
+        {/* Action buttons — only for recipient on non-terminal estados */}
+        {showActions && (
+          <div className="flex gap-1.5 pt-0.5">
+            {canImport && (
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-7 flex-1 text-[11px] px-2"
+                disabled={importMutation.isPending}
+                onClick={() => void handleImport()}
+              >
+                {importMutation.isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  "Importar"
+                )}
+              </Button>
+            )}
+
+            {canFulfill && (
+              <Button
+                size="sm"
+                className="h-7 flex-1 text-[11px] px-2"
+                disabled={fulfill.isPending}
+                onClick={() => setConfirmFulfillOpen(true)}
+              >
+                {fulfill.isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  "Enviar directo"
+                )}
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Permission-based notice when recipient but no permissions */}
+        {isRecipient && !isTerminal && !canImport && !canFulfill && (
+          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <XCircle className="h-3 w-3 shrink-0 text-muted-foreground/60" />
+            <span>Sin permisos para actuar sobre esta solicitud</span>
+          </div>
+        )}
+      </div>
+
+      {/* Confirm fulfill modal */}
+      <ConfirmFulfillModal
+        open={confirmFulfillOpen}
+        onClose={() => setConfirmFulfillOpen(false)}
+        onConfirm={() => void handleFulfillConfirm()}
+        isPending={fulfill.isPending}
+      />
+
+      {/* Fulfill result modal */}
+      {fulfillResult && (
+        <FulfillResultModal
+          open={!!fulfillResult}
+          onClose={() => setFulfillResult(null)}
+          result={fulfillResult}
+        />
+      )}
+    </>
+  );
+}

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -12,7 +12,7 @@
 
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import { Loader2, ArrowRight, Package, CheckCircle2, XCircle } from "lucide-react";
+import { Loader2, ArrowRight, Package, CheckCircle2, XCircle, ExternalLink } from "lucide-react";
 import { showErrorToast, showWarningToast } from "@/hooks/use-toast-enhanced";
 import { Button } from "@/components/atoms/button";
 import { Badge } from "@/components/atoms/badge";
@@ -391,11 +391,24 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
           </ul>
         )}
 
-        {/* Terminal estado indicator (no buttons) */}
+        {/* Terminal estado indicator + optional transfer link */}
         {isTerminal && (
-          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-            <CheckCircle2 className="h-3 w-3 shrink-0" />
-            <span>Esta solicitud ya fue procesada</span>
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+              <CheckCircle2 className="h-3 w-3 shrink-0" />
+              <span>Esta solicitud ya fue procesada</span>
+            </div>
+            {request.product_transfer_id && (
+              <Button
+                size="sm"
+                variant="secondary"
+                className="h-7 w-full text-[11px] px-2 gap-1.5"
+                onClick={() => navigate(`/dashboard/transfers/${request.product_transfer_id}`)}
+              >
+                <ExternalLink className="h-3 w-3" />
+                Ver transferencia
+              </Button>
+            )}
           </div>
         )}
 

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -30,10 +30,11 @@ import {
 import { cn } from "@/lib/utils";
 import { PERMISSIONS } from "@/lib/permissions";
 import { usePermissionCheck } from "@/hooks/usePermissionCheck";
-import type { TransferRequestEstado, FulfillDirectResult } from "@/modules/transfers/types/transferRequest.types";
+import type { TransferRequestEstado, FulfillDirectResult, FulfilledItem, SkippedItem } from "@/modules/transfers/types/transferRequest.types";
 import { useTransferRequestById } from "@/modules/transfers/hooks/useTransferRequestById";
 import { useImportTransferRequest } from "@/modules/transfers/hooks/useImportTransferRequest";
 import { useFulfillTransferRequest } from "@/modules/transfers/hooks/useFulfillTransferRequest";
+import { transferRequestService } from "@/modules/transfers/services/transferRequestService";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ESTADO BADGE
@@ -106,11 +107,30 @@ function FulfillResultModal({ open, onClose, onGoToTransfer, result }: FulfillRe
                 {result.fulfilled_items.map((item) => (
                   <div
                     key={item.producto_id}
-                    className="flex items-center justify-between rounded-lg bg-emerald-50 dark:bg-emerald-500/10 px-2.5 py-1.5 text-xs"
+                    className={`flex items-center justify-between rounded-lg px-2.5 py-1.5 text-xs ${
+                      item.was_partial
+                        ? "bg-amber-50 dark:bg-amber-500/10"
+                        : "bg-emerald-50 dark:bg-emerald-500/10"
+                    }`}
                   >
-                    <span className="text-foreground">{item.producto_descripcion}</span>
-                    <span className="font-semibold text-emerald-700 dark:text-emerald-300 ml-2">
-                      ×{item.cantidad}
+                    <div>
+                      <span className="text-foreground">{item.producto_descripcion}</span>
+                      {item.was_partial && (
+                        <span className="block text-[10px] text-amber-600 dark:text-amber-400">
+                          Stock insuficiente — enviado parcialmente
+                        </span>
+                      )}
+                    </div>
+                    <span
+                      className={`font-semibold ml-2 ${
+                        item.was_partial
+                          ? "text-amber-700 dark:text-amber-300"
+                          : "text-emerald-700 dark:text-emerald-300"
+                      }`}
+                    >
+                      {item.was_partial
+                        ? `×${item.cantidad} de ${item.cantidad_solicitada}`
+                        : `×${item.cantidad}`}
                     </span>
                   </div>
                 ))}
@@ -120,24 +140,17 @@ function FulfillResultModal({ open, onClose, onGoToTransfer, result }: FulfillRe
 
           {result.skipped_items.length > 0 && (
             <div>
-              <p className="text-xs font-semibold text-amber-600 dark:text-amber-400 mb-1.5">
-                No despachados ({result.skipped_items.length})
+              <p className="text-xs font-semibold text-red-600 dark:text-red-400 mb-1.5">
+                Sin stock — no despachados ({result.skipped_items.length})
               </p>
               <div className="space-y-1">
                 {result.skipped_items.map((item) => (
                   <div
                     key={item.producto_id}
-                    className="flex items-center justify-between rounded-lg bg-amber-50 dark:bg-amber-500/10 px-2.5 py-1.5 text-xs"
+                    className="flex items-center justify-between rounded-lg bg-red-50 dark:bg-red-500/10 px-2.5 py-1.5 text-xs"
                   >
-                    <div>
-                      <span className="text-foreground">{item.producto_descripcion}</span>
-                      <span className="block text-[10px] text-muted-foreground">
-                        {item.reason === "NO_STOCK" || item.reason === "INSUFFICIENT_STOCK"
-                          ? "Sin stock disponible"
-                          : "Producto inactivo"}
-                      </span>
-                    </div>
-                    <span className="font-semibold text-amber-700 dark:text-amber-300 ml-2">
+                    <span className="text-foreground">{item.producto_descripcion}</span>
+                    <span className="font-semibold text-red-700 dark:text-red-300 ml-2">
                       ×{item.cantidad_solicitada}
                     </span>
                   </div>
@@ -154,7 +167,7 @@ function FulfillResultModal({ open, onClose, onGoToTransfer, result }: FulfillRe
           {onGoToTransfer && result.transfer_id && (
             <Button size="sm" onClick={onGoToTransfer} className="gap-1.5">
               <ExternalLink className="h-3.5 w-3.5" />
-              Ir a confirmar envío
+              Ver transferencia
             </Button>
           )}
         </DialogFooter>
@@ -172,6 +185,9 @@ interface ConfirmFulfillModalProps {
   onClose: () => void;
   onConfirm: () => void;
   isPending: boolean;
+  isLoadingPreview: boolean;
+  fulfilledItems: FulfilledItem[];
+  skippedItems: SkippedItem[];
 }
 
 function ConfirmFulfillModal({
@@ -179,31 +195,99 @@ function ConfirmFulfillModal({
   onClose,
   onConfirm,
   isPending,
+  isLoadingPreview,
+  fulfilledItems,
+  skippedItems,
 }: ConfirmFulfillModalProps) {
   return (
     <Dialog open={open} onOpenChange={(v) => !v && !isPending && onClose()}>
-      <DialogContent className="max-w-sm z-[9999]">
+      <DialogContent className="max-w-md z-[9999]">
         <DialogHeader>
           <DialogTitle>Enviar directo</DialogTitle>
           <DialogDescription>
             Se creará una transferencia con los productos disponibles en tu
-            sucursal. Los productos sin stock serán omitidos. Esta acción no
-            se puede deshacer.
+            sucursal. Esta acción no se puede deshacer.
           </DialogDescription>
         </DialogHeader>
+
+        {isLoadingPreview ? (
+          <div className="flex items-center justify-center py-6 gap-2 text-muted-foreground text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Verificando stock…
+          </div>
+        ) : (
+          <div className="space-y-3 max-h-60 overflow-y-auto">
+            {fulfilledItems.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-emerald-600 dark:text-emerald-400 mb-1.5">
+                  Se enviarán ({fulfilledItems.length})
+                </p>
+                <div className="space-y-1">
+                  {fulfilledItems.map((item) => (
+                    <div
+                      key={item.producto_id}
+                      className={`flex items-center justify-between rounded-lg px-2.5 py-1.5 text-xs ${
+                        item.was_partial
+                          ? "bg-amber-50 dark:bg-amber-500/10"
+                          : "bg-emerald-50 dark:bg-emerald-500/10"
+                      }`}
+                    >
+                      <div>
+                        <span className="text-foreground">{item.producto_descripcion}</span>
+                        {item.was_partial && (
+                          <span className="block text-[10px] text-amber-600 dark:text-amber-400">
+                            Stock insuficiente — se ajustará la cantidad
+                          </span>
+                        )}
+                      </div>
+                      <span className={`font-semibold ml-2 ${item.was_partial ? "text-amber-700 dark:text-amber-300" : "text-emerald-700 dark:text-emerald-300"}`}>
+                        {item.was_partial
+                          ? `×${item.cantidad} de ${item.cantidad_solicitada}`
+                          : `×${item.cantidad}`}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {skippedItems.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-red-600 dark:text-red-400 mb-1.5">
+                  Sin stock — se omitirán ({skippedItems.length})
+                </p>
+                <div className="space-y-1">
+                  {skippedItems.map((item) => (
+                    <div
+                      key={item.producto_id}
+                      className="flex items-center justify-between rounded-lg bg-red-50 dark:bg-red-500/10 px-2.5 py-1.5 text-xs"
+                    >
+                      <span className="text-foreground">{item.producto_descripcion}</span>
+                      <span className="font-semibold text-red-700 dark:text-red-300 ml-2">
+                        ×{item.cantidad_solicitada}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {fulfilledItems.length === 0 && skippedItems.length === 0 && (
+              <p className="text-xs text-muted-foreground text-center py-2">
+                Sin productos para enviar.
+              </p>
+            )}
+          </div>
+        )}
+
         <DialogFooter className="gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onClose}
-            disabled={isPending}
-          >
+          <Button variant="outline" size="sm" onClick={onClose} disabled={isPending}>
             Cancelar
           </Button>
           <Button
             size="sm"
             onClick={onConfirm}
-            disabled={isPending}
+            disabled={isPending || isLoadingPreview || fulfilledItems.length === 0}
           >
             {isPending ? (
               <>
@@ -254,6 +338,8 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
   // ── Modal states ──────────────────────────────────────────────────────────
   const [confirmFulfillOpen, setConfirmFulfillOpen] = useState(false);
   const [fulfillResult, setFulfillResult] = useState<FulfillDirectResult | null>(null);
+  const [preview, setPreview] = useState<{ fulfilled_items: FulfilledItem[]; skipped_items: SkippedItem[] } | null>(null);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 
   // ── Derived state ─────────────────────────────────────────────────────────
   const isRecipient =
@@ -473,10 +559,21 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
               <Button
                 size="sm"
                 className="h-7 flex-1 text-[11px] px-2"
-                disabled={fulfill.isPending}
-                onClick={() => setConfirmFulfillOpen(true)}
+                disabled={fulfill.isPending || isLoadingPreview}
+                onClick={() => {
+                  setPreview(null);
+                  setIsLoadingPreview(true);
+                  setConfirmFulfillOpen(true);
+                  void transferRequestService.previewFulfillDirect(requestId).then((data) => {
+                    setPreview(data);
+                    setIsLoadingPreview(false);
+                  }).catch(() => {
+                    setConfirmFulfillOpen(false);
+                    setIsLoadingPreview(false);
+                  });
+                }}
               >
-                {fulfill.isPending ? (
+                {isLoadingPreview ? (
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 ) : (
                   "Enviar directo"
@@ -498,9 +595,12 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
       {/* Confirm fulfill modal */}
       <ConfirmFulfillModal
         open={confirmFulfillOpen}
-        onClose={() => setConfirmFulfillOpen(false)}
+        onClose={() => { setConfirmFulfillOpen(false); setPreview(null); }}
         onConfirm={() => void handleFulfillConfirm()}
         isPending={fulfill.isPending}
+        isLoadingPreview={isLoadingPreview}
+        fulfilledItems={preview?.fulfilled_items ?? []}
+        skippedItems={preview?.skipped_items ?? []}
       />
 
       {/* Fulfill result modal */}

--- a/src/modules/messaging/components/TransferRequestCard.tsx
+++ b/src/modules/messaging/components/TransferRequestCard.tsx
@@ -398,7 +398,7 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
               <CheckCircle2 className="h-3 w-3 shrink-0" />
               <span>Esta solicitud ya fue procesada</span>
             </div>
-            {request.product_transfer_id && (
+            {request.product_transfer_id ? (
               <Button
                 size="sm"
                 variant="secondary"
@@ -407,6 +407,16 @@ export function TransferRequestCard({ requestId, currentUserId, isMine = false }
               >
                 <ExternalLink className="h-3 w-3" />
                 Ver transferencia
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 w-full text-[11px] px-2 gap-1.5 text-muted-foreground"
+                onClick={() => navigate("/dashboard/transfers")}
+              >
+                <ExternalLink className="h-3 w-3" />
+                Ver transferencias
               </Button>
             )}
           </div>

--- a/src/modules/messaging/hooks/useMessagingWebSocket.ts
+++ b/src/modules/messaging/hooks/useMessagingWebSocket.ts
@@ -28,6 +28,7 @@ import type {
 import { resolveNotificationBehavior } from "../utils/messageNotifications";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { messagesQueryKey } from "./useMessages";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "@/modules/transfers/constants/transferRequestQueryKeys";
 
 const POLL_INTERVAL_MS = 7000;
 const ECHO_CHECK_INTERVAL_MS = 5000;
@@ -384,6 +385,17 @@ export function useMessagingWebSocket(chats: Chat[], isEchoConnected: boolean) {
         channelName,
         "chat.deleted",
         (data: ChatDeletedEvent) => handleChatDeleted(chatId, data),
+      );
+
+      // Estado de solicitud de transferencia cambiado — invalidar caché para re-render del card
+      websocketService.listen(
+        channelName,
+        "transfer_request.updated",
+        (data: { id: number }) => {
+          void qc.invalidateQueries({
+            queryKey: TRANSFER_REQUEST_QUERY_KEYS.detail(data.id),
+          });
+        },
       );
 
       subscribedChats.current.add(chatId);

--- a/src/modules/messaging/hooks/useSendAttachment.ts
+++ b/src/modules/messaging/hooks/useSendAttachment.ts
@@ -72,8 +72,8 @@ export function useSendAttachment(chatId: number) {
                 es_imagen: true,
                 url: localPreviewUrl ?? "",
                 url_thumbnail: localPreviewUrl ?? null,
-                ancho: null,
-                alto: null,
+                ancho: payload.width ?? null,
+                alto: payload.height ?? null,
               },
             ]
           : [
@@ -120,8 +120,8 @@ export function useSendAttachment(chatId: number) {
           return;
         }
 
-        // Limpiar objectURL en error también
-        if (localPreviewUrl) URL.revokeObjectURL(localPreviewUrl);
+        // No revocar localPreviewUrl aquí — la imagen necesita ser visible en estado fallido
+        // El cleanup ocurre en retry() o cuando el mensaje es eliminado
         markFailed(chatId, tempId);
         // Re-lanzar para que el componente pueda mostrar el error
         throw error;

--- a/src/modules/messaging/stores/ChatStore.ts
+++ b/src/modules/messaging/stores/ChatStore.ts
@@ -2,6 +2,9 @@ import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { Message, OptimisticMessage } from "../types/Message.types";
 import type { Chat } from "../types/Chat.types";
+import { chatService } from "../service/Chat.service";
+import { messageService } from "../service/Message.service";
+import { useChatUIStore } from "./ChatUiStore";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // HELPERS
@@ -163,6 +166,19 @@ interface ChatActions {
 
   // Reset
   reset: () => void;
+
+  // ── Transfer Requests ─────────────────────────────────────────────────────
+
+  /**
+   * Crea o reutiliza un DM con `toUserId`, luego envía un mensaje
+   * de tipo transfer_request con la referencia al pedido.
+   * Abre el panel de chat apuntando al chat correcto.
+   */
+  sendTransferRequest: (params: {
+    toUserId: number;
+    transferRequestId: number;
+    itemCount: number;
+  }) => Promise<void>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -184,7 +200,7 @@ const initialState: ChatState = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const useChatStore = create<ChatState & ChatActions>()(
-  immer((set) => ({
+  immer((set, get) => ({
     ...initialState,
 
     // ── Chats ──────────────────────────────────────────────────────────────
@@ -491,6 +507,45 @@ export const useChatStore = create<ChatState & ChatActions>()(
       set((state) => {
         state.lastMessageTimestampByChatId[chatId] = timestamp;
       }),
+
+    // ── Transfer Requests ──────────────────────────────────────────────────
+
+    sendTransferRequest: async ({ toUserId, transferRequestId, itemCount }) => {
+      // 1. Check if a DIRECT chat with toUserId already exists in the store.
+      const { chats } = get();
+      let chat = chats.find(
+        (c) =>
+          c.tipo === "DIRECT" &&
+          c.participantes.some((p) => p.usuario?.id === toUserId),
+      ) ?? null;
+
+      // 2. If no DM exists, create/retrieve it via the backend.
+      if (!chat) {
+        chat = await chatService.createDirect({ usuario_id: toUserId });
+        // Upsert into the store so subsequent operations can find it.
+        useChatStore.getState().upsertChat(chat);
+      }
+
+      // 3. Send the transfer request message.
+      const plural = itemCount !== 1 ? "s" : "";
+      await messageService.send(chat.id, {
+        contenido: `Solicitud de transferencia — ${itemCount} producto${plural}`,
+        referencia_tipo: "transfer_request",
+        referencia_id: transferRequestId,
+      });
+
+      // 4. Open the chat panel and navigate to the chat.
+      set((state) => {
+        state.activeChatId = chat!.id;
+        state.pendingDirectChat = null;
+        try {
+          localStorage.setItem("messaging_last_chat_id", String(chat!.id));
+        } catch {
+          // localStorage not available
+        }
+      });
+      useChatUIStore.getState().open();
+    },
 
     // ── Reset ──────────────────────────────────────────────────────────────
 

--- a/src/modules/messaging/stores/ChatStore.ts
+++ b/src/modules/messaging/stores/ChatStore.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import type { Message, OptimisticMessage } from "../types/Message.types";
@@ -526,13 +527,40 @@ export const useChatStore = create<ChatState & ChatActions>()(
         useChatStore.getState().upsertChat(chat);
       }
 
-      // 3. Send the transfer request message.
+      // 3. Send the transfer request message — optimistic first, then confirm.
       const plural = itemCount !== 1 ? "s" : "";
-      await messageService.send(chat.id, {
+      const msgPayload = {
         contenido: `Solicitud de transferencia — ${itemCount} producto${plural}`,
-        referencia_tipo: "transfer_request",
+        referencia_tipo: "transfer_request" as const,
         referencia_id: transferRequestId,
-      });
+      };
+      const tempId = nanoid();
+      const optimistic: OptimisticMessage = {
+        id: -Date.now(),
+        chat_id: chat.id,
+        tipo: "TEXT",
+        tipo_label: "Texto",
+        contenido: msgPayload.contenido,
+        referencia_tipo: msgPayload.referencia_tipo,
+        referencia_id: msgPayload.referencia_id,
+        remitente: null,
+        subtipo: null,
+        actor_id: null,
+        es_sistema: false,
+        editado: false,
+        fecha_reg: new Date().toISOString(),
+        fecha_editado: null,
+        adjuntos: [],
+        _tempId: tempId,
+        _status: "sending",
+      };
+      useChatStore.getState().appendMessage(chat.id, optimistic);
+      try {
+        const message = await messageService.send(chat.id, msgPayload);
+        useChatStore.getState().replaceOptimisticMessage(chat.id, tempId, message);
+      } catch {
+        useChatStore.getState().markOptimisticAsFailed(chat.id, tempId);
+      }
 
       // 4. Open the chat panel and navigate to the chat.
       set((state) => {

--- a/src/modules/messaging/stores/ChatUiStore.ts
+++ b/src/modules/messaging/stores/ChatUiStore.ts
@@ -12,6 +12,16 @@ interface FloatingSize {
   h: number;
 }
 
+export const DEFAULT_FLOATING_SIZE: FloatingSize = { w: 420, h: 580 };
+
+function getDefaultPos(): FloatingPos {
+  if (typeof window === "undefined") return { x: 100, y: 100 };
+  return {
+    x: window.innerWidth - DEFAULT_FLOATING_SIZE.w - 24,
+    y: window.innerHeight - DEFAULT_FLOATING_SIZE.h - 24,
+  };
+}
+
 interface ChatUIState {
   isOpen: boolean;
   isMinimized: boolean;
@@ -19,6 +29,8 @@ interface ChatUIState {
   floatingPos: FloatingPos;
   floatingSize: FloatingSize;
   fabHidden: boolean;
+  isMaximized: boolean;
+  preMaximizeLayout: { pos: FloatingPos; size: FloatingSize } | null;
   // ── Scroll preservation ──
   conversationListScroll: number;
   chatPositionOnEnter: number;
@@ -33,20 +45,12 @@ interface ChatUIActions {
   setFloatingPos: (pos: FloatingPos) => void;
   setFloatingSize: (size: FloatingSize) => void;
   setFabHidden: (hidden: boolean) => void;
+  setIsMaximized: (v: boolean) => void;
+  setPreMaximizeLayout: (layout: { pos: FloatingPos; size: FloatingSize } | null) => void;
   // ── Scroll preservation ──
   setConversationListScroll: (y: number) => void;
   setChatPositionOnEnter: (pos: number) => void;
   setLastVisitedChatId: (id: number | null) => void;
-}
-
-const DEFAULT_SIZE: FloatingSize = { w: 420, h: 580 };
-
-function getDefaultPos(): FloatingPos {
-  if (typeof window === "undefined") return { x: 100, y: 100 };
-  return {
-    x: window.innerWidth - DEFAULT_SIZE.w - 24,
-    y: window.innerHeight - DEFAULT_SIZE.h - 24,
-  };
 }
 
 export const useChatUIStore = create<ChatUIState & ChatUIActions>()(
@@ -56,8 +60,10 @@ export const useChatUIStore = create<ChatUIState & ChatUIActions>()(
       isMinimized: false,
       viewMode: "floating",
       floatingPos: getDefaultPos(),
-      floatingSize: DEFAULT_SIZE,
+      floatingSize: DEFAULT_FLOATING_SIZE,
       fabHidden: false,
+      isMaximized: false,
+      preMaximizeLayout: null,
       conversationListScroll: 0,
       chatPositionOnEnter: -1,
       lastVisitedChatId: null,
@@ -81,18 +87,23 @@ export const useChatUIStore = create<ChatUIState & ChatUIActions>()(
 
       setFabHidden: (hidden) => set({ fabHidden: hidden }),
 
+      setIsMaximized: (v) => set({ isMaximized: v }),
+
+      setPreMaximizeLayout: (layout) => set({ preMaximizeLayout: layout }),
+
       setConversationListScroll: (y) => set({ conversationListScroll: y }),
       setChatPositionOnEnter: (pos) => set({ chatPositionOnEnter: pos }),
       setLastVisitedChatId: (id) => set({ lastVisitedChatId: id }),
     }),
     {
       name: "chat-ui-store",
-      // Only persist layout preferences
       partialize: (s) => ({
         viewMode: s.viewMode,
         floatingPos: s.floatingPos,
         floatingSize: s.floatingSize,
         fabHidden: s.fabHidden,
+        isMaximized: s.isMaximized,
+        preMaximizeLayout: s.preMaximizeLayout,
       }),
     },
   ),

--- a/src/modules/messaging/types/Attachment.types.ts
+++ b/src/modules/messaging/types/Attachment.types.ts
@@ -23,6 +23,9 @@ export interface SendAttachmentPayload {
   file: File;
   /** Caption opcional — equivalente al campo "contenido" */
   caption?: string;
+  /** Dimensiones reales de la imagen — reservan espacio en el optimista para evitar layout shift */
+  width?: number;
+  height?: number;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/modules/messaging/types/Message.types.ts
+++ b/src/modules/messaging/types/Message.types.ts
@@ -35,6 +35,7 @@ export type ReferenciaTipo =
   | "sale"
   | "purchase"
   | "transfer"
+  | "transfer_request"
   | string;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/modules/transfers/constants/index.ts
+++ b/src/modules/transfers/constants/index.ts
@@ -1,0 +1,3 @@
+export * from "./transferCommonsQueryKeys";
+export * from "./transferQueryKeys";
+export * from "./transferRequestQueryKeys";

--- a/src/modules/transfers/constants/transferRequestQueryKeys.ts
+++ b/src/modules/transfers/constants/transferRequestQueryKeys.ts
@@ -1,0 +1,30 @@
+/**
+ * Query keys for Transfer Requests
+ *
+ * Follows the same nested-object pattern used throughout the project.
+ */
+export const TRANSFER_REQUEST_QUERY_KEYS = {
+  /** Base key for all transfer request queries */
+  all: ["transfer-requests"] as const,
+
+  /** Base key for all detail queries */
+  details: () => [...TRANSFER_REQUEST_QUERY_KEYS.all, "detail"] as const,
+
+  /**
+   * Key for a specific transfer request by ID
+   * @param id - Transfer request ID
+   * @example TRANSFER_REQUEST_QUERY_KEYS.detail(42)
+   */
+  detail: (id: number) =>
+    [...TRANSFER_REQUEST_QUERY_KEYS.details(), id] as const,
+
+  /**
+   * Key for the import data of a specific transfer request.
+   * Separate from detail because import is a mutation that also transitions
+   * request estado — distinct caching concern.
+   * @param id - Transfer request ID
+   * @example TRANSFER_REQUEST_QUERY_KEYS.importData(42)
+   */
+  importData: (id: number) =>
+    [...TRANSFER_REQUEST_QUERY_KEYS.all, "import", id] as const,
+};

--- a/src/modules/transfers/hooks/useCreateTransferRequest.ts
+++ b/src/modules/transfers/hooks/useCreateTransferRequest.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "../constants/transferRequestQueryKeys";
+import { transferRequestService } from "../services/transferRequestService";
+import type { CreateTransferRequestPayload } from "../types/transferRequest.types";
+
+export const useCreateTransferRequest = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (data: CreateTransferRequestPayload) =>
+            transferRequestService.create(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: TRANSFER_REQUEST_QUERY_KEYS.all,
+            });
+        },
+    });
+};

--- a/src/modules/transfers/hooks/useFulfillTransferRequest.ts
+++ b/src/modules/transfers/hooks/useFulfillTransferRequest.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "../constants/transferRequestQueryKeys";
+import { transferRequestService } from "../services/transferRequestService";
+
+export const useFulfillTransferRequest = (id: number) => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => transferRequestService.fulfillDirect(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: TRANSFER_REQUEST_QUERY_KEYS.detail(id),
+            });
+        },
+    });
+};

--- a/src/modules/transfers/hooks/useImportTransferRequest.ts
+++ b/src/modules/transfers/hooks/useImportTransferRequest.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+import { transferRequestService } from "../services/transferRequestService";
+
+export const useImportTransferRequest = (id: number) => {
+    return useMutation({
+        mutationFn: () => transferRequestService.import(id),
+        // No cache invalidation — caller receives ImportResult and navigates away.
+        // The estado transition (IMPORTED) is handled server-side; the request
+        // query cache will be stale but the user is no longer on this screen.
+    });
+};

--- a/src/modules/transfers/hooks/useImportTransferRequest.ts
+++ b/src/modules/transfers/hooks/useImportTransferRequest.ts
@@ -1,11 +1,15 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "../constants/transferRequestQueryKeys";
 import { transferRequestService } from "../services/transferRequestService";
 
 export const useImportTransferRequest = (id: number) => {
+    const queryClient = useQueryClient();
     return useMutation({
         mutationFn: () => transferRequestService.import(id),
-        // No cache invalidation — caller receives ImportResult and navigates away.
-        // The estado transition (IMPORTED) is handled server-side; the request
-        // query cache will be stale but the user is no longer on this screen.
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: TRANSFER_REQUEST_QUERY_KEYS.detail(id),
+            });
+        },
     });
 };

--- a/src/modules/transfers/hooks/useLinkTransferRequest.ts
+++ b/src/modules/transfers/hooks/useLinkTransferRequest.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "../constants/transferRequestQueryKeys";
+import { transferRequestService } from "../services/transferRequestService";
+
+export const useLinkTransferRequest = () => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ requestId, transferId }: { requestId: number; transferId: number }) =>
+            transferRequestService.linkTransfer(requestId, transferId),
+        onSuccess: (_data, { requestId }) => {
+            queryClient.invalidateQueries({
+                queryKey: TRANSFER_REQUEST_QUERY_KEYS.detail(requestId),
+            });
+        },
+    });
+};

--- a/src/modules/transfers/hooks/useTransferDetails.ts
+++ b/src/modules/transfers/hooks/useTransferDetails.ts
@@ -3,8 +3,10 @@ import type { TransferDetailCreate, UITransferDetailCreate } from "../types/tran
 import type { ProductGet } from "@/modules/products/types/ProductGet";
 import type { ProductStock } from "@/modules/products/types/productStock";
 
-export const useTransferDetails = () => {
-    const [details, setDetails] = useState<UITransferDetailCreate[]>([]);
+export const useTransferDetails = (
+    options: { initialDetails?: UITransferDetailCreate[] } = {}
+) => {
+    const [details, setDetails] = useState<UITransferDetailCreate[]>(() => options.initialDetails ?? []);
 
     // Añadir un producto al detalle.
     // Si se proveen `lots` (FIFO, más antiguo primero), se crea UNA sola fila con el saldo

--- a/src/modules/transfers/hooks/useTransferRequestById.ts
+++ b/src/modules/transfers/hooks/useTransferRequestById.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { TRANSFER_REQUEST_QUERY_KEYS } from "../constants/transferRequestQueryKeys";
+import { transferRequestService } from "../services/transferRequestService";
+
+export const useTransferRequestById = (id: number | undefined) => {
+    return useQuery({
+        queryKey: TRANSFER_REQUEST_QUERY_KEYS.detail(id!),
+        queryFn: () => transferRequestService.getById(id!),
+        staleTime: 0,
+        enabled: !!id,
+    });
+};

--- a/src/modules/transfers/schemas/transferRequest.schema.ts
+++ b/src/modules/transfers/schemas/transferRequest.schema.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ITEM SCHEMAS
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CreateTransferRequestItemSchema = z.object({
+  producto_id: z.number().int().positive(),
+  cantidad_solicitada: z.number().positive(),
+});
+
+export const TransferRequestItemSchema = z.object({
+  id: z.number().int().positive(),
+  producto_id: z.number().int().positive(),
+  producto_descripcion: z.string(),
+  cantidad_solicitada: z.number().positive(),
+  cantidad_cumplida: z.number().nullable(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CREATE PAYLOAD SCHEMA (for form validation)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CreateTransferRequestPayloadSchema = z.object({
+  sucursal_solicitante_id: z.number().int().positive(),
+  sucursal_destinataria_id: z.number().int().positive(),
+  usuario_destinatario_id: z.number().int().positive(),
+  items: z.array(CreateTransferRequestItemSchema).min(1, {
+    message: "Debe incluir al menos un producto en la solicitud",
+  }),
+  notas: z.string().optional(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET RESPONSE SCHEMA (for API response parsing)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TransferRequestEstadoSchema = z.enum([
+  "PENDING",
+  "FULFILLED",
+  "IMPORTED",
+  "PARTIAL",
+  "CANCELLED",
+]);
+
+export const TransferRequestGetSchema = z.object({
+  id: z.number().int().positive(),
+  sucursal_solicitante_id: z.number(),
+  sucursal_solicitante_nombre: z.string(),
+  sucursal_destinataria_id: z.number(),
+  sucursal_destinataria_nombre: z.string(),
+  usuario_solicitante_id: z.number(),
+  usuario_solicitante_nombre: z.string(),
+  usuario_destinatario_id: z.number(),
+  usuario_destinatario_nombre: z.string(),
+  estado: TransferRequestEstadoSchema,
+  notas: z.string().nullable(),
+  chat_message_id: z.number().nullable(),
+  items: z.array(TransferRequestItemSchema),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// INFERRED TYPES (from schemas)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CreateTransferRequestPayloadInput = z.input<
+  typeof CreateTransferRequestPayloadSchema
+>;

--- a/src/modules/transfers/schemas/transferRequest.schema.ts
+++ b/src/modules/transfers/schemas/transferRequest.schema.ts
@@ -56,6 +56,7 @@ export const TransferRequestGetSchema = z.object({
   estado: TransferRequestEstadoSchema,
   notas: z.string().nullable(),
   chat_message_id: z.number().nullable(),
+  product_transfer_id: z.number().nullable().optional(),
   items: z.array(TransferRequestItemSchema),
   created_at: z.string(),
   updated_at: z.string(),

--- a/src/modules/transfers/schemas/transferRequest.schema.ts
+++ b/src/modules/transfers/schemas/transferRequest.schema.ts
@@ -39,6 +39,7 @@ const TransferRequestEstadoSchema = z.enum([
   "pending",
   "fulfilled",
   "imported",
+  "in_progress",
   "partial",
   "cancelled",
 ]);

--- a/src/modules/transfers/schemas/transferRequest.schema.ts
+++ b/src/modules/transfers/schemas/transferRequest.schema.ts
@@ -36,11 +36,11 @@ export const CreateTransferRequestPayloadSchema = z.object({
 // ─────────────────────────────────────────────────────────────────────────────
 
 const TransferRequestEstadoSchema = z.enum([
-  "PENDING",
-  "FULFILLED",
-  "IMPORTED",
-  "PARTIAL",
-  "CANCELLED",
+  "pending",
+  "fulfilled",
+  "imported",
+  "partial",
+  "cancelled",
 ]);
 
 export const TransferRequestGetSchema = z.object({

--- a/src/modules/transfers/screens/CreateTransfer.tsx
+++ b/src/modules/transfers/screens/CreateTransfer.tsx
@@ -39,7 +39,7 @@ import {
   type FieldErrors,
 } from "react-hook-form";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import type { TransferDetailTableRef } from "../components/TransferDetailTable";
 import TransferDetailTable from "../components/TransferDetailTable";
 import { useTransferBranches } from "../hooks/commons/useTransferBranches";
@@ -48,18 +48,70 @@ import { useCreateTransfer } from "../hooks/useCreateTransfer";
 import { useGetBranchById } from "@/modules/settings/hooks/branch/useGetBranchById";
 import { useTransferDetails } from "../hooks/useTransferDetails";
 import { TransferCreateSchema } from "../schemas/transferCreateSchema";
-import type { TransferCreate } from "../types/transferCreate.types";
+import type { TransferCreate, UITransferDetailCreate } from "../types/transferCreate.types";
 import { ProtectedAction } from "@/components/common/ProtectedAction";
 import { PERMISSIONS } from "@/lib/permissions";
+import type { ImportResult } from "../types/transferRequest.types";
+
+// Build UITransferDetailCreate rows from ImportResult items.
+// Same shape that addProduct() produces when called with lots.
+const buildPrefillRows = (prefill: ImportResult): UITransferDetailCreate[] =>
+  prefill.items.flatMap((item) => {
+    if (!item.lots || item.lots.length === 0) return [];
+    const lotsAsc = [...item.lots].sort(
+      (a, b) =>
+        new Date(a.fecha_adquisicion).getTime() -
+        new Date(b.fecha_adquisicion).getTime()
+    );
+    const totalSaldo = lotsAsc.reduce((sum, lot) => sum + lot.saldo, 0);
+    const oldestLot = lotsAsc[0];
+    const product = item.product;
+    return [
+      {
+        producto_id: product.id,
+        cantidad_entrada_salida: Math.min(item.cantidad_solicitada, totalSaldo),
+        costo_entrada: oldestLot.costo,
+        precio_salida: product.precio_venta,
+        precio_entrada_venta: product.precio_venta,
+        precio_entrada_venta_alt: product.precio_venta_alt,
+        incremento_p_entrada_venta: 0,
+        incremento_p_entrada_venta_alt: 0,
+        tc_transfer: oldestLot.tc_compra || 0,
+        purchase_id: oldestLot.id,
+        lots: lotsAsc,
+        total_saldo: totalSaldo,
+        product: {
+          id: product.id,
+          descripcion: product.descripcion,
+          codigo_oem: product.codigo_oem,
+          codigo_upc: product.codigo_upc,
+          marca: product.marca || null,
+          costo: oldestLot.costo,
+          precio_venta: product.precio_venta,
+          precio_venta_alt: product.precio_venta_alt,
+        },
+      } satisfies UITransferDetailCreate,
+    ];
+  });
 
 const CreateTransfer = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // Read prefill state ONCE at mount — never re-read on re-renders
+  const transferRequestPrefill = (location.state as { transferRequestPrefill?: ImportResult } | null)
+    ?.transferRequestPrefill;
+
+  const prefillRows = transferRequestPrefill
+    ? buildPrefillRows(transferRequestPrefill)
+    : undefined;
+
   const user = authSDK.getCurrentUser();
   const { selectedBranchId } = useBranchStore();
   const tableRef = useRef<TransferDetailTableRef>(null);
 
-  // Hook de detalles de transferencia
-  const transferDetailsHook = useTransferDetails();
+  // Hook de detalles de transferencia — pre-populated from import flow when available
+  const transferDetailsHook = useTransferDetails({ initialDetails: prefillRows });
 
   const { data: transferResponsiblesData } = useTransferResponsibles();
 
@@ -82,7 +134,8 @@ const CreateTransfer = () => {
       nro_comprobante: "",
       comentarios: "",
       sucursal_origen: Number(selectedBranchId) || 1,
-      sucursal_destino: undefined,
+      // Pre-fill sucursal_destino from import flow; undefined triggers auto-select
+      sucursal_destino: transferRequestPrefill?.sucursal_destinataria_id ?? undefined,
       responsable: Number(user?._id) || undefined,
       detalles: [],
     },

--- a/src/modules/transfers/screens/CreateTransfer.tsx
+++ b/src/modules/transfers/screens/CreateTransfer.tsx
@@ -47,6 +47,7 @@ import { useTransferResponsibles } from "../hooks/commons/useTransferResponsible
 import { useCreateTransfer } from "../hooks/useCreateTransfer";
 import { useGetBranchById } from "@/modules/settings/hooks/branch/useGetBranchById";
 import { useTransferDetails } from "../hooks/useTransferDetails";
+import { useLinkTransferRequest } from "../hooks/useLinkTransferRequest";
 import { TransferCreateSchema } from "../schemas/transferCreateSchema";
 import type { TransferCreate, UITransferDetailCreate } from "../types/transferCreate.types";
 import { ProtectedAction } from "@/components/common/ProtectedAction";
@@ -138,6 +139,7 @@ const CreateTransfer = () => {
   );
 
   const { mutate: createTransfer, isPending: isSaving } = useCreateTransfer();
+  const { mutate: linkTransferRequest } = useLinkTransferRequest();
 
   const { handleError } = useErrorHandler();
 
@@ -268,7 +270,16 @@ const CreateTransfer = () => {
     };
 
     createTransfer(adjustedData, {
-      onSuccess: () => {
+      onSuccess: (created) => {
+        // If this transfer came from an import prefill, mark the request as fulfilled
+        // and link the created transfer so the chat card can show "Ver transferencia".
+        const createdId = (created as { id?: number } | null)?.id;
+        if (transferRequestPrefill?.request_id && createdId) {
+          linkTransferRequest({
+            requestId: transferRequestPrefill.request_id,
+            transferId: createdId,
+          });
+        }
         showSuccessToast({
           title: "Transferencia Exitosa",
           description: `Transferencia realizada con éxito`,

--- a/src/modules/transfers/screens/CreateTransfer.tsx
+++ b/src/modules/transfers/screens/CreateTransfer.tsx
@@ -273,7 +273,10 @@ const CreateTransfer = () => {
       onSuccess: (created) => {
         // If this transfer came from an import prefill, mark the request as fulfilled
         // and link the created transfer so the chat card can show "Ver transferencia".
-        const createdId = (created as { id?: number } | null)?.id;
+        // Laravel JsonResource wraps in { data: {...} } — unwrap before accessing id.
+        const createdId =
+          (created as { data?: { id?: number } } | null)?.data?.id ??
+          (created as { id?: number } | null)?.id;
         if (transferRequestPrefill?.request_id && createdId) {
           linkTransferRequest({
             requestId: transferRequestPrefill.request_id,

--- a/src/modules/transfers/screens/CreateTransfer.tsx
+++ b/src/modules/transfers/screens/CreateTransfer.tsx
@@ -58,37 +58,51 @@ import type { ImportResult } from "../types/transferRequest.types";
 const buildPrefillRows = (prefill: ImportResult): UITransferDetailCreate[] =>
   prefill.items.flatMap((item) => {
     if (!item.lots || item.lots.length === 0) return [];
-    const lotsAsc = [...item.lots].sort(
-      (a, b) =>
-        new Date(a.fecha_adquisicion).getTime() -
-        new Date(b.fecha_adquisicion).getTime()
-    );
+    // Laravel raw query results return PostgreSQL numerics as strings —
+    // coerce every numeric field to Number() so strictRequiredMoneySchema passes.
+    const lotsAsc = [...item.lots]
+      .map((lot) => ({
+        ...lot,
+        id: Number(lot.id),
+        saldo: Number(lot.saldo),
+        costo: Number(lot.costo) || 0,
+        precio_venta: Number(lot.precio_venta) || 0,
+        precio_venta_alt: Number(lot.precio_venta_alt) || 0,
+        tc_compra: Number(lot.tc_compra) || 0,
+      }))
+      .sort(
+        (a, b) =>
+          new Date(a.fecha_adquisicion).getTime() -
+          new Date(b.fecha_adquisicion).getTime()
+      );
     const totalSaldo = lotsAsc.reduce((sum, lot) => sum + lot.saldo, 0);
     const oldestLot = lotsAsc[0];
     const product = item.product;
+    const precioVenta = Number(product.precio_venta ?? oldestLot.precio_venta) || 0;
+    const precioVentaAlt = Number(product.precio_venta_alt ?? oldestLot.precio_venta_alt) || 0;
     return [
       {
-        producto_id: product.id,
-        cantidad_entrada_salida: Math.min(item.cantidad_solicitada, totalSaldo),
+        producto_id: Number(product.id),
+        cantidad_entrada_salida: Math.min(Number(item.cantidad_solicitada), totalSaldo),
         costo_entrada: oldestLot.costo,
-        precio_salida: product.precio_venta,
-        precio_entrada_venta: product.precio_venta,
-        precio_entrada_venta_alt: product.precio_venta_alt,
+        precio_salida: precioVenta,
+        precio_entrada_venta: precioVenta,
+        precio_entrada_venta_alt: precioVentaAlt,
         incremento_p_entrada_venta: 0,
         incremento_p_entrada_venta_alt: 0,
-        tc_transfer: oldestLot.tc_compra || 0,
+        tc_transfer: oldestLot.tc_compra,
         purchase_id: oldestLot.id,
         lots: lotsAsc,
         total_saldo: totalSaldo,
         product: {
-          id: product.id,
+          id: Number(product.id),
           descripcion: product.descripcion,
           codigo_oem: product.codigo_oem,
           codigo_upc: product.codigo_upc,
           marca: product.marca || null,
           costo: oldestLot.costo,
-          precio_venta: product.precio_venta,
-          precio_venta_alt: product.precio_venta_alt,
+          precio_venta: precioVenta,
+          precio_venta_alt: precioVentaAlt,
         },
       } satisfies UITransferDetailCreate,
     ];
@@ -134,8 +148,10 @@ const CreateTransfer = () => {
       nro_comprobante: "",
       comentarios: "",
       sucursal_origen: Number(selectedBranchId) || 1,
-      // Pre-fill sucursal_destino from import flow; undefined triggers auto-select
-      sucursal_destino: transferRequestPrefill?.sucursal_destinataria_id ?? undefined,
+      // Pre-fill sucursal_destino from import flow.
+      // The SOLICITANTE is who needs the products → destination of this transfer.
+      // (sucursal_destinataria is the branch that HAS stock = current user = origin)
+      sucursal_destino: transferRequestPrefill?.sucursal_solicitante_id ?? undefined,
       responsable: Number(user?._id) || undefined,
       detalles: [],
     },
@@ -278,19 +294,27 @@ const CreateTransfer = () => {
       });
       return;
     }
+
+    if (errors.detalles) {
+      // Array field errors don't surface .message at the root — check explicitly.
+      const detailsMsg = (errors.detalles as { message?: string }).message;
+      validateBeforeSubmit();
+      showErrorToast({
+        title: "Error en los productos",
+        description: detailsMsg ?? "Verifica que los productos y precios sean válidos",
+        duration: 5000,
+      });
+      return;
+    }
+
     const firstErrorKey = Object.keys(errors)[0] as keyof TransferCreate;
     const firstError = errors[firstErrorKey];
-
     if (firstError?.message) {
       showErrorToast({
         title: "Error en formulario",
         description: firstError.message,
         duration: 5000,
       });
-    }
-
-    if (errors.detalles) {
-      validateBeforeSubmit();
     }
   };
 
@@ -304,15 +328,14 @@ const CreateTransfer = () => {
   };
 
   useEffect(() => {
-    if (
-      !user?._id &&
-      transferResponsiblesData &&
-      transferResponsiblesData.data.length > 0
-    ) {
-      const firstResponsible = transferResponsiblesData.data[0];
-      setValue("responsable", firstResponsible.id);
+    if (!transferResponsiblesData?.data.length) return;
+    const currentResponsable = methods.getValues("responsable");
+    // Only auto-select first responsible when no value is set
+    // (avoids overriding current user's ID set in defaultValues)
+    if (!currentResponsable) {
+      setValue("responsable", transferResponsiblesData.data[0].id);
     }
-  }, [transferResponsiblesData, setValue, user?._id]);
+  }, [transferResponsiblesData, setValue, methods]);
 
   // Auto-seleccionar la primera sucursal destino disponible
   useEffect(() => {

--- a/src/modules/transfers/screens/TransferRequestCreatePage.tsx
+++ b/src/modules/transfers/screens/TransferRequestCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useChatStore } from "@/modules/messaging/stores/ChatStore";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import type { TransferRequest } from "../types/transferRequest.types";
 import TransferRequestCreateScreen from "./TransferRequestCreateScreen";
 
@@ -17,7 +17,9 @@ import TransferRequestCreateScreen from "./TransferRequestCreateScreen";
  */
 const TransferRequestCreatePage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const sendTransferRequest = useChatStore((s) => s.sendTransferRequest);
+  const initialDestinatario = location.state?.destinatario ?? null;
 
   const handleSuccess = async (request: TransferRequest) => {
     await sendTransferRequest({
@@ -28,7 +30,7 @@ const TransferRequestCreatePage = () => {
     navigate("/dashboard/transfers");
   };
 
-  return <TransferRequestCreateScreen onSuccess={handleSuccess} />;
+  return <TransferRequestCreateScreen onSuccess={handleSuccess} initialDestinatario={initialDestinatario} />;
 };
 
 export default TransferRequestCreatePage;

--- a/src/modules/transfers/screens/TransferRequestCreatePage.tsx
+++ b/src/modules/transfers/screens/TransferRequestCreatePage.tsx
@@ -1,0 +1,34 @@
+import { useChatStore } from "@/modules/messaging/stores/ChatStore";
+import { useNavigate } from "react-router";
+import type { TransferRequest } from "../types/transferRequest.types";
+import TransferRequestCreateScreen from "./TransferRequestCreateScreen";
+
+/**
+ * Route-level wrapper for TransferRequestCreateScreen.
+ *
+ * The Tab system renders route elements as `<Component />` (no props).
+ * This wrapper wires the `onSuccess` callback to ChatStore.sendTransferRequest
+ * so the screen does not need to know about the chat layer directly.
+ *
+ * Flow on success:
+ *   1. Create request → receive TransferRequest
+ *   2. Call ChatStore.sendTransferRequest (creates DM if needed + sends message)
+ *   3. Navigate back to transfers list
+ */
+const TransferRequestCreatePage = () => {
+  const navigate = useNavigate();
+  const sendTransferRequest = useChatStore((s) => s.sendTransferRequest);
+
+  const handleSuccess = async (request: TransferRequest) => {
+    await sendTransferRequest({
+      toUserId: request.usuario_destinatario_id,
+      transferRequestId: request.id,
+      itemCount: request.items.length,
+    });
+    navigate("/dashboard/transfers");
+  };
+
+  return <TransferRequestCreateScreen onSuccess={handleSuccess} />;
+};
+
+export default TransferRequestCreatePage;

--- a/src/modules/transfers/screens/TransferRequestCreateScreen.tsx
+++ b/src/modules/transfers/screens/TransferRequestCreateScreen.tsx
@@ -1,0 +1,689 @@
+import { Button } from "@/components/atoms/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/atoms/card";
+import { Input } from "@/components/atoms/input";
+import { Label } from "@/components/atoms/label";
+import { Separator } from "@/components/atoms/separator";
+import { Textarea } from "@/components/atoms/textarea";
+import { ProtectedAction } from "@/components/common/ProtectedAction";
+import { showErrorToast, showSuccessToast } from "@/hooks/use-toast-enhanced";
+import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { PERMISSIONS } from "@/lib/permissions";
+import { cn } from "@/lib/utils";
+import {
+  useMessagingUsersFlat,
+  useMessagingUsersGrouped,
+  useUserAllSucursalesMap,
+} from "@/modules/messaging/hooks/useMessagingUsers";
+import type { MessagingUser } from "@/modules/messaging/types/MessagingUser.types";
+import { useGetBranchById } from "@/modules/settings/hooks/branch/useGetBranchById";
+import { useBranchStore } from "@/states/branchStore";
+import {
+  ArrowLeftRight,
+  CornerUpLeft,
+  Loader2,
+  Plus,
+  Save,
+  Search,
+  ShieldAlert,
+  Trash2,
+  User,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { useCreateTransferRequest } from "../hooks/useCreateTransferRequest";
+import type {
+  CreateTransferRequestItem,
+  TransferRequest,
+} from "../types/transferRequest.types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TYPES
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ProductRow {
+  /** Unique row key — product ID (one row per product for simplicity) */
+  producto_id: number;
+  descripcion: string;
+  cantidad_solicitada: number;
+}
+
+interface Props {
+  /** Called after a successful request creation. Phase 4 wires this to ChatStore. */
+  onSuccess?: (request: TransferRequest) => void;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SUCURSAL BADGES (reused pattern from UserSelectorPanel)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SucursalBadges({ siglas }: { siglas: string[] }) {
+  if (!siglas.length) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-0.5">
+      {siglas.map((s) => (
+        <span
+          key={s}
+          className="rounded px-1 py-0.5 text-[9px] font-bold bg-muted text-muted-foreground leading-none"
+        >
+          {s}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// USER PICKER INLINE (based on UserSelectorPanel pattern)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface UserPickerProps {
+  selectedUser: MessagingUser | null;
+  onSelect: (user: MessagingUser) => void;
+  onClear: () => void;
+  error?: string;
+}
+
+function UserPicker({ selectedUser, onSelect, onClear, error }: UserPickerProps) {
+  const [search, setSearch] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { users, isLoading } = useMessagingUsersFlat(search.trim() || undefined);
+  const allSucursalesMap = useUserAllSucursalesMap();
+
+  const handleSelect = (user: MessagingUser) => {
+    onSelect(user);
+    setIsOpen(false);
+    setSearch("");
+  };
+
+  if (selectedUser) {
+    const siglas = allSucursalesMap.get(selectedUser.id) ?? [];
+    return (
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm",
+          error ? "border-destructive" : "border-input"
+        )}
+      >
+        <User className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="flex-1 truncate font-medium">{selectedUser.nombre}</span>
+        <SucursalBadges siglas={siglas} />
+        <button
+          type="button"
+          onClick={onClear}
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-md border bg-background px-3 py-2 text-sm cursor-pointer",
+          error ? "border-destructive" : "border-input",
+          isOpen && "ring-2 ring-ring ring-offset-background"
+        )}
+        onClick={() => setIsOpen((v) => !v)}
+      >
+        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        {isOpen ? (
+          <input
+            autoFocus
+            className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
+            placeholder="Buscar usuario..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className="flex-1 text-muted-foreground">
+            Seleccionar destinatario...
+          </span>
+        )}
+      </div>
+
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-background shadow-md max-h-60 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : users.length === 0 ? (
+            <div className="py-6 text-center text-xs text-muted-foreground">
+              {search.trim() ? `Sin resultados para "${search}"` : "Sin usuarios disponibles"}
+            </div>
+          ) : (
+            users.map((u) => {
+              const siglas = allSucursalesMap.get(u.id) ?? [];
+              return (
+                <button
+                  key={u.id}
+                  type="button"
+                  className="flex w-full items-center gap-3 px-3 py-2 text-left text-sm hover:bg-accent/40 transition-colors"
+                  onClick={() => handleSelect(u)}
+                >
+                  <User className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="flex-1 truncate font-medium">{u.nombre}</span>
+                  <SucursalBadges siglas={siglas} />
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PRODUCT SEARCH ROW (inline search for adding product rows)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ProductSearchRowProps {
+  onAdd: (producto_id: number, descripcion: string) => void;
+  existingIds: Set<number>;
+}
+
+function ProductSearchRow({ onAdd, existingIds }: ProductSearchRowProps) {
+  const [search, setSearch] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [results, setResults] = useState<{ id: number; descripcion: string }[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const handleSearch = async (query: string) => {
+    setSearch(query);
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+    setIsSearching(true);
+    try {
+      const { productsService } = await import(
+        "@/modules/products/services/productService"
+      );
+      const data = await productsService.getAll({
+        descripcion: query,
+        pagina: 1,
+        pagina_registros: 20,
+      });
+      setResults(
+        (data?.data ?? []).map((p: { id: number; descripcion: string }) => ({
+          id: p.id,
+          descripcion: p.descripcion,
+        }))
+      );
+    } catch {
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const handleSelect = (producto_id: number, descripcion: string) => {
+    if (existingIds.has(producto_id)) return;
+    onAdd(producto_id, descripcion);
+    setSearch("");
+    setResults([]);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-background">
+        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <input
+          className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
+          placeholder="Buscar producto para agregar..."
+          value={search}
+          onFocus={() => setIsOpen(true)}
+          onBlur={() => setTimeout(() => setIsOpen(false), 150)}
+          onChange={(e) => {
+            handleSearch(e.target.value);
+            setIsOpen(true);
+          }}
+        />
+        {isSearching && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+        {search && !isSearching && (
+          <button
+            type="button"
+            onClick={() => { setSearch(""); setResults([]); }}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+
+      {isOpen && results.length > 0 && (
+        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-background shadow-md max-h-52 overflow-y-auto">
+          {results.map((p) => {
+            const alreadyAdded = existingIds.has(p.id);
+            return (
+              <button
+                key={p.id}
+                type="button"
+                disabled={alreadyAdded}
+                className={cn(
+                  "flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors",
+                  alreadyAdded
+                    ? "opacity-40 cursor-not-allowed"
+                    : "hover:bg-accent/40"
+                )}
+                onMouseDown={() => handleSelect(p.id, p.descripcion)}
+              >
+                <Plus className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{p.descripcion}</span>
+                {alreadyAdded && (
+                  <span className="text-[10px] text-muted-foreground">ya agregado</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MAIN SCREEN
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
+  const navigate = useNavigate();
+  const { selectedBranchId } = useBranchStore();
+
+  // ── Form state ───────────────────────────────────────────────────────────
+  const [destinatario, setDestinatario] = useState<MessagingUser | null>(null);
+  const [items, setItems] = useState<ProductRow[]>([]);
+  const [notas, setNotas] = useState("");
+
+  // ── Errors ───────────────────────────────────────────────────────────────
+  const [destinatarioError, setDestinatarioError] = useState("");
+  const [itemsError, setItemsError] = useState("");
+
+  // ── Hooks ────────────────────────────────────────────────────────────────
+  const { mutateAsync: createRequest, isPending } = useCreateTransferRequest();
+  const { handleError } = useErrorHandler();
+
+  // Origin branch name
+  const { data: originBranchData } = useGetBranchById(
+    Number(selectedBranchId) || 1
+  );
+
+  // Build userId → sucursalId map for resolving destinatario's branch
+  const { groups } = useMessagingUsersGrouped();
+  const userBranchMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const group of groups) {
+      for (const u of group.usuarios) {
+        if (!map.has(u.id)) {
+          map.set(u.id, group.sucursal.id);
+        }
+      }
+    }
+    return map;
+  }, [groups]);
+
+  const existingProductIds = new Set(items.map((i) => i.producto_id));
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  const handleAddProduct = (producto_id: number, descripcion: string) => {
+    setItems((prev) => [
+      ...prev,
+      { producto_id, descripcion, cantidad_solicitada: 1 },
+    ]);
+    if (itemsError) setItemsError("");
+  };
+
+  const handleRemoveProduct = (producto_id: number) => {
+    setItems((prev) => prev.filter((r) => r.producto_id !== producto_id));
+  };
+
+  const handleCantidadChange = (producto_id: number, raw: string) => {
+    const value = parseFloat(raw);
+    if (isNaN(value) || value <= 0) return;
+    setItems((prev) =>
+      prev.map((r) =>
+        r.producto_id === producto_id
+          ? { ...r, cantidad_solicitada: value }
+          : r
+      )
+    );
+  };
+
+  const validate = (): boolean => {
+    let valid = true;
+
+    if (!destinatario) {
+      setDestinatarioError("Debes seleccionar un destinatario");
+      valid = false;
+    } else {
+      setDestinatarioError("");
+    }
+
+    if (items.length === 0) {
+      setItemsError("Debes agregar al menos un producto");
+      valid = false;
+    } else {
+      setItemsError("");
+    }
+
+    return valid;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const sucursalDestinatariaId = userBranchMap.get(destinatario!.id);
+    if (!sucursalDestinatariaId) {
+      showErrorToast({
+        title: "Error de validación",
+        description: "No se pudo determinar la sucursal del destinatario",
+        duration: 4000,
+      });
+      return;
+    }
+
+    const payload = {
+      sucursal_solicitante_id: Number(selectedBranchId) || 1,
+      sucursal_destinataria_id: sucursalDestinatariaId,
+      usuario_destinatario_id: destinatario!.id,
+      items: items.map(
+        (r): CreateTransferRequestItem => ({
+          producto_id: r.producto_id,
+          cantidad_solicitada: r.cantidad_solicitada,
+        })
+      ),
+      notas: notas.trim() || undefined,
+    };
+
+    try {
+      const result = await createRequest(payload);
+      showSuccessToast({
+        title: "Solicitud creada",
+        description: `Solicitud de transferencia creada con ${items.length} producto${items.length !== 1 ? "s" : ""}`,
+        duration: 4000,
+      });
+      onSuccess?.(result);
+    } catch (error) {
+      handleError({
+        error,
+        customTitle: "No se pudo crear la solicitud",
+      });
+    }
+  };
+
+  const handleGoBack = () => {
+    navigate("/dashboard/transfers");
+  };
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <main className="h-full flex flex-col">
+      <ProtectedAction
+        permission={PERMISSIONS.TRA.REQUEST_CREATE}
+        roles={["Super Admin", "Administrador", "Vendedor"]}
+        showLoader={true}
+      >
+        <form
+          onSubmit={handleSubmit}
+          className="h-full flex flex-col gap-2 p-2"
+        >
+          {/* Header */}
+          <header className="border-border border bg-background rounded-lg p-2 sm:px-3 flex-shrink-0">
+            <div className="flex flex-wrap gap-2 items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="default"
+                  size="icon"
+                  onClick={handleGoBack}
+                  className="h-8 w-8"
+                >
+                  <CornerUpLeft className="h-4 w-4" />
+                </Button>
+                <div>
+                  <h1 className="text-lg lg:text-xl font-bold text-foreground leading-tight">
+                    Nueva Solicitud de Transferencia
+                  </h1>
+                  <p className="text-sm text-muted-foreground">
+                    Solicita productos a otra sucursal
+                  </p>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          {/* 1. Datos de la solicitud */}
+          <Card className="shadow-none flex-shrink-0">
+            <CardContent className="py-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {/* Destinatario */}
+                <div className="w-full">
+                  <Label className="text-xs">Destinatario *</Label>
+                  <div className="mt-1">
+                    <UserPicker
+                      selectedUser={destinatario}
+                      onSelect={(u) => {
+                        setDestinatario(u);
+                        setDestinatarioError("");
+                      }}
+                      onClear={() => setDestinatario(null)}
+                      error={destinatarioError}
+                    />
+                    {destinatarioError && (
+                      <p className="text-destructive text-xs mt-0.5">
+                        {destinatarioError}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Sucursal solicitante (read-only — current branch) */}
+                <div className="w-full">
+                  <Label className="text-xs">Sucursal Solicitante</Label>
+                  <Input
+                    disabled
+                    value={originBranchData?.nombre ?? "Cargando..."}
+                    className="bg-muted text-xs h-8 mt-1"
+                  />
+                </div>
+
+                {/* Notas */}
+                <div className="w-full sm:col-span-2">
+                  <Label htmlFor="notas" className="text-xs">
+                    Notas
+                  </Label>
+                  <Textarea
+                    id="notas"
+                    value={notas}
+                    onChange={(e) => setNotas(e.target.value)}
+                    placeholder="Notas adicionales sobre la solicitud..."
+                    rows={2}
+                    className="w-full text-xs min-h-8 mt-1"
+                  />
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 2. Productos */}
+          <Card className="shadow-none flex-1 min-h-0 flex flex-col">
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-base flex items-center gap-2">
+                <ArrowLeftRight className="size-4" />
+                Productos Solicitados
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex-1 min-h-0 flex flex-col gap-3">
+              {/* Product search input */}
+              <ProductSearchRow
+                onAdd={handleAddProduct}
+                existingIds={existingProductIds}
+              />
+
+              {itemsError && (
+                <p className="text-destructive text-xs">{itemsError}</p>
+              )}
+
+              {/* Product rows */}
+              {items.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground flex-1 flex flex-col items-center justify-center">
+                  <ArrowLeftRight className="h-10 w-10 mx-auto mb-3 text-muted-foreground/40" />
+                  <p className="text-sm">Sin productos agregados</p>
+                  <p className="text-xs">
+                    Buscá un producto arriba para agregarlo a la solicitud
+                  </p>
+                </div>
+              ) : (
+                <div className="flex-1 min-h-0 overflow-auto">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="border-b border-border">
+                        <th className="text-left py-2 px-2 font-medium text-muted-foreground">
+                          Producto
+                        </th>
+                        <th className="text-right py-2 px-2 font-medium text-muted-foreground w-28">
+                          Cantidad
+                        </th>
+                        <th className="w-10" />
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {items.map((row) => (
+                        <tr
+                          key={row.producto_id}
+                          className="border-b border-border/50 hover:bg-muted/20 transition-colors"
+                        >
+                          <td className="py-2 px-2 font-medium truncate max-w-0">
+                            <span className="block truncate">
+                              {row.descripcion}
+                            </span>
+                          </td>
+                          <td className="py-2 px-2 text-right">
+                            <Input
+                              type="number"
+                              min="0.01"
+                              step="0.01"
+                              value={row.cantidad_solicitada}
+                              onChange={(e) =>
+                                handleCantidadChange(
+                                  row.producto_id,
+                                  e.target.value
+                                )
+                              }
+                              className="h-7 text-xs text-right w-24 ml-auto"
+                            />
+                          </td>
+                          <td className="py-2 px-2">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                              onClick={() =>
+                                handleRemoveProduct(row.producto_id)
+                              }
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </Button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {items.length > 0 && (
+                <>
+                  <Separator className="h-[0.5px] flex-shrink-0" />
+                  <div className="flex justify-between items-center px-2 flex-shrink-0">
+                    <span className="font-medium text-muted-foreground text-xs">
+                      Total de productos:
+                    </span>
+                    <span className="font-bold text-foreground text-sm">
+                      {items.length} producto{items.length !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+                </>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Footer */}
+          <Card className="border border-border shadow-none pt-3 flex-shrink-0">
+            <CardContent className="space-y-2">
+              <footer className="flex gap-2 items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  * Campos requeridos
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="font-medium"
+                    onClick={handleGoBack}
+                  >
+                    Cancelar
+                  </Button>
+                  <ProtectedAction
+                    permission={PERMISSIONS.TRA.REQUEST_CREATE}
+                    roles={["Super Admin", "Administrador", "Vendedor"]}
+                    fallback={
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        disabled
+                      >
+                        <ShieldAlert className="mr-2 size-4" />
+                        Sin permisos
+                      </Button>
+                    }
+                    showUnauthorizedMessage={false}
+                  >
+                    <Button
+                      type="submit"
+                      size="sm"
+                      disabled={isPending}
+                      variant="default"
+                    >
+                      {isPending ? (
+                        <>
+                          <Loader2 className="mr-2 size-4 animate-spin" />
+                          Creando solicitud...
+                        </>
+                      ) : (
+                        <>
+                          <Save className="mr-2 size-4" />
+                          Crear Solicitud
+                        </>
+                      )}
+                    </Button>
+                  </ProtectedAction>
+                </div>
+              </footer>
+            </CardContent>
+          </Card>
+        </form>
+      </ProtectedAction>
+    </main>
+  );
+};
+
+export default TransferRequestCreateScreen;

--- a/src/modules/transfers/screens/TransferRequestCreateScreen.tsx
+++ b/src/modules/transfers/screens/TransferRequestCreateScreen.tsx
@@ -12,6 +12,7 @@ import { Textarea } from "@/components/atoms/textarea";
 import { ProtectedAction } from "@/components/common/ProtectedAction";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast-enhanced";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
+import { useProductSelectorWindow } from "@/hooks/useSecondaryWindow";
 import { PERMISSIONS } from "@/lib/permissions";
 import { cn } from "@/lib/utils";
 import {
@@ -56,6 +57,8 @@ interface ProductRow {
 interface Props {
   /** Called after a successful request creation. Phase 4 wires this to ChatStore. */
   onSuccess?: (request: TransferRequest) => void;
+  /** Pre-selected recipient (e.g. navigated from a chat conversation). */
+  initialDestinatario?: MessagingUser | null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -87,13 +90,17 @@ interface UserPickerProps {
   onSelect: (user: MessagingUser) => void;
   onClear: () => void;
   error?: string;
+  excludeUserIds?: Set<number>;
 }
 
-function UserPicker({ selectedUser, onSelect, onClear, error }: UserPickerProps) {
+function UserPicker({ selectedUser, onSelect, onClear, error, excludeUserIds }: UserPickerProps) {
   const [search, setSearch] = useState("");
   const [isOpen, setIsOpen] = useState(false);
 
-  const { users, isLoading } = useMessagingUsersFlat(search.trim() || undefined);
+  const { users: allUsers, isLoading } = useMessagingUsersFlat(search.trim() || undefined);
+  const users = excludeUserIds?.size
+    ? allUsers.filter((u) => !excludeUserIds.has(u.id))
+    : allUsers;
   const allSucursalesMap = useUserAllSucursalesMap();
 
   const handleSelect = (user: MessagingUser) => {
@@ -185,126 +192,19 @@ function UserPicker({ selectedUser, onSelect, onClear, error }: UserPickerProps)
   );
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// PRODUCT SEARCH ROW (inline search for adding product rows)
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface ProductSearchRowProps {
-  onAdd: (producto_id: number, descripcion: string) => void;
-  existingIds: Set<number>;
-}
-
-function ProductSearchRow({ onAdd, existingIds }: ProductSearchRowProps) {
-  const [search, setSearch] = useState("");
-  const [isOpen, setIsOpen] = useState(false);
-  const [results, setResults] = useState<{ id: number; descripcion: string }[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-
-  const handleSearch = async (query: string) => {
-    setSearch(query);
-    if (!query.trim()) {
-      setResults([]);
-      return;
-    }
-    setIsSearching(true);
-    try {
-      const { productsService } = await import(
-        "@/modules/products/services/productService"
-      );
-      const data = await productsService.getAll({
-        descripcion: query,
-        pagina: 1,
-        pagina_registros: 20,
-      });
-      setResults(
-        (data?.data ?? []).map((p: { id: number; descripcion: string }) => ({
-          id: p.id,
-          descripcion: p.descripcion,
-        }))
-      );
-    } catch {
-      setResults([]);
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
-  const handleSelect = (producto_id: number, descripcion: string) => {
-    if (existingIds.has(producto_id)) return;
-    onAdd(producto_id, descripcion);
-    setSearch("");
-    setResults([]);
-    setIsOpen(false);
-  };
-
-  return (
-    <div className="relative">
-      <div className="flex items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-background">
-        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        <input
-          className="flex-1 bg-transparent outline-none text-sm placeholder:text-muted-foreground"
-          placeholder="Buscar producto para agregar..."
-          value={search}
-          onFocus={() => setIsOpen(true)}
-          onBlur={() => setTimeout(() => setIsOpen(false), 150)}
-          onChange={(e) => {
-            handleSearch(e.target.value);
-            setIsOpen(true);
-          }}
-        />
-        {isSearching && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
-        {search && !isSearching && (
-          <button
-            type="button"
-            onClick={() => { setSearch(""); setResults([]); }}
-            className="text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        )}
-      </div>
-
-      {isOpen && results.length > 0 && (
-        <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-background shadow-md max-h-52 overflow-y-auto">
-          {results.map((p) => {
-            const alreadyAdded = existingIds.has(p.id);
-            return (
-              <button
-                key={p.id}
-                type="button"
-                disabled={alreadyAdded}
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition-colors",
-                  alreadyAdded
-                    ? "opacity-40 cursor-not-allowed"
-                    : "hover:bg-accent/40"
-                )}
-                onMouseDown={() => handleSelect(p.id, p.descripcion)}
-              >
-                <Plus className="h-3 w-3 shrink-0 text-muted-foreground" />
-                <span className="flex-1 truncate">{p.descripcion}</span>
-                {alreadyAdded && (
-                  <span className="text-[10px] text-muted-foreground">ya agregado</span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MAIN SCREEN
 // ─────────────────────────────────────────────────────────────────────────────
 
-const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
+const TransferRequestCreateScreen = ({ onSuccess, initialDestinatario }: Props) => {
   const navigate = useNavigate();
   const { selectedBranchId } = useBranchStore();
 
   // ── Form state ───────────────────────────────────────────────────────────
-  const [destinatario, setDestinatario] = useState<MessagingUser | null>(null);
+  const [destinatario, setDestinatario] = useState<MessagingUser | null>(
+    () => initialDestinatario ?? null
+  );
   const [items, setItems] = useState<ProductRow[]>([]);
   const [notas, setNotas] = useState("");
 
@@ -321,31 +221,72 @@ const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
     Number(selectedBranchId) || 1
   );
 
-  // Build userId → sucursalId map for resolving destinatario's branch
+  // Build userId → sucursalId map for resolving destinatario's branch.
+  // Prefer non-current-branch entries: a user can appear in multiple groups;
+  // we want their "other" branch, not the one matching the requester.
   const { groups } = useMessagingUsersGrouped();
+  const currentBranchId = Number(selectedBranchId) || 1;
   const userBranchMap = useMemo(() => {
     const map = new Map<number, number>();
     for (const group of groups) {
       for (const u of group.usuarios) {
-        if (!map.has(u.id)) {
+        const existing = map.get(u.id);
+        // Set if unseen, or overwrite only if the current entry is the same branch
+        if (existing === undefined || existing === currentBranchId) {
           map.set(u.id, group.sucursal.id);
         }
       }
     }
     return map;
-  }, [groups]);
+  }, [groups, currentBranchId]);
 
-  const existingProductIds = new Set(items.map((i) => i.producto_id));
+  // IDs of users whose resolved branch equals the requester's branch — excluded from picker
+  const sameBranchUserIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const [userId, branchId] of userBranchMap) {
+      if (branchId === currentBranchId) ids.add(userId);
+    }
+    return ids;
+  }, [userBranchMap, currentBranchId]);
 
-  // ── Handlers ─────────────────────────────────────────────────────────────
-
-  const handleAddProduct = (producto_id: number, descripcion: string) => {
-    setItems((prev) => [
-      ...prev,
-      { producto_id, descripcion, cantidad_solicitada: 1 },
-    ]);
+  // ── Product selector window ───────────────────────────────────────────────
+  const mergeProducts = (incoming: ProductRow[]) => {
+    setItems((prev) => {
+      const existingIds = new Set(prev.map((r) => r.producto_id));
+      const newItems = incoming.filter((r) => !existingIds.has(r.producto_id));
+      return [...prev, ...newItems];
+    });
     if (itemsError) setItemsError("");
   };
+
+  const productWindow = useProductSelectorWindow({
+    context: "transfer-request",
+    multiSelect: true,
+    mode: "create",
+    validateStock: false,
+    // Handles multi-select confirm (array)
+    onMultiSelect: (products) => {
+      mergeProducts(
+        products.map((p) => ({
+          producto_id: p.id,
+          descripcion: p.descripcion,
+          cantidad_solicitada: p.quantity ?? 1,
+        }))
+      );
+    },
+    // Fallback: window fires single-select event even in multiSelect mode
+    onProductSelect: (product) => {
+      mergeProducts([
+        {
+          producto_id: product.id,
+          descripcion: product.descripcion,
+          cantidad_solicitada: product.quantity ?? 1,
+        },
+      ]);
+    },
+  });
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
 
   const handleRemoveProduct = (producto_id: number) => {
     setItems((prev) => prev.filter((r) => r.producto_id !== producto_id));
@@ -392,6 +333,14 @@ const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
       showErrorToast({
         title: "Error de validación",
         description: "No se pudo determinar la sucursal del destinatario",
+        duration: 4000,
+      });
+      return;
+    }
+    if (sucursalDestinatariaId === currentBranchId) {
+      showErrorToast({
+        title: "Sucursal inválida",
+        description: "El destinatario debe pertenecer a una sucursal diferente a la tuya.",
         duration: 4000,
       });
       return;
@@ -483,6 +432,7 @@ const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
                       }}
                       onClear={() => setDestinatario(null)}
                       error={destinatarioError}
+                      excludeUserIds={sameBranchUserIds}
                     />
                     {destinatarioError && (
                       <p className="text-destructive text-xs mt-0.5">
@@ -527,13 +477,21 @@ const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
                 <ArrowLeftRight className="size-4" />
                 Productos Solicitados
               </CardTitle>
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => productWindow.open()}
+                disabled={productWindow.isLoading}
+              >
+                {productWindow.isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Plus className="mr-2 h-4 w-4" />
+                )}
+                Agregar Productos
+              </Button>
             </CardHeader>
             <CardContent className="flex-1 min-h-0 flex flex-col gap-3">
-              {/* Product search input */}
-              <ProductSearchRow
-                onAdd={handleAddProduct}
-                existingIds={existingProductIds}
-              />
 
               {itemsError && (
                 <p className="text-destructive text-xs">{itemsError}</p>
@@ -545,7 +503,7 @@ const TransferRequestCreateScreen = ({ onSuccess }: Props) => {
                   <ArrowLeftRight className="h-10 w-10 mx-auto mb-3 text-muted-foreground/40" />
                   <p className="text-sm">Sin productos agregados</p>
                   <p className="text-xs">
-                    Buscá un producto arriba para agregarlo a la solicitud
+                    Hacé clic en "Agregar Productos" para seleccionarlos
                   </p>
                 </div>
               ) : (

--- a/src/modules/transfers/screens/index.ts
+++ b/src/modules/transfers/screens/index.ts
@@ -1,0 +1,6 @@
+export { default as CreateTransfer } from "./CreateTransfer";
+export { default as EditTransfer } from "./EditTransfer";
+export { default as TransferDetailScreen } from "./TransferDetailScreen";
+export { default as TransferListScreen } from "./TransferListScreen";
+export { default as TransferRequestCreateScreen } from "./TransferRequestCreateScreen";
+export { default as TransferRequestCreatePage } from "./TransferRequestCreatePage";

--- a/src/modules/transfers/services/transferRequestEndpoints.service.ts
+++ b/src/modules/transfers/services/transferRequestEndpoints.service.ts
@@ -1,6 +1,7 @@
 export const TRANSFER_REQUEST_ENDPOINTS = {
     base: "/transfer-requests",
     byId: (id: number) => `/transfer-requests/${id}`,
+    fulfillDirectPreview: (id: number) => `/transfer-requests/${id}/fulfill-direct/preview`,
     fulfillDirect: (id: number) => `/transfer-requests/${id}/fulfill-direct`,
     import: (id: number) => `/transfer-requests/${id}/import`,
     linkTransfer: (id: number) => `/transfer-requests/${id}/link-transfer`,

--- a/src/modules/transfers/services/transferRequestEndpoints.service.ts
+++ b/src/modules/transfers/services/transferRequestEndpoints.service.ts
@@ -1,0 +1,6 @@
+export const TRANSFER_REQUEST_ENDPOINTS = {
+    base: "/transfer-requests",
+    byId: (id: number) => `/transfer-requests/${id}`,
+    fulfillDirect: (id: number) => `/transfer-requests/${id}/fulfill-direct`,
+    import: (id: number) => `/transfer-requests/${id}/import`,
+};

--- a/src/modules/transfers/services/transferRequestEndpoints.service.ts
+++ b/src/modules/transfers/services/transferRequestEndpoints.service.ts
@@ -3,4 +3,5 @@ export const TRANSFER_REQUEST_ENDPOINTS = {
     byId: (id: number) => `/transfer-requests/${id}`,
     fulfillDirect: (id: number) => `/transfer-requests/${id}/fulfill-direct`,
     import: (id: number) => `/transfer-requests/${id}/import`,
+    linkTransfer: (id: number) => `/transfer-requests/${id}/link-transfer`,
 };

--- a/src/modules/transfers/services/transferRequestService.ts
+++ b/src/modules/transfers/services/transferRequestService.ts
@@ -72,4 +72,21 @@ export const transferRequestService = {
         Logger.info("Transfer Request imported successfully", { id }, MODULE_NAME);
         return response;
     },
+
+    /**
+     * Link a created transfer to an imported request and mark it as fulfilled.
+     * Called after the recipient creates the actual transfer from an import prefill.
+     * @param id - Transfer request ID
+     * @param transferId - ID of the ProductTransfer that was created
+     */
+    async linkTransfer(id: number, transferId: number): Promise<void> {
+        Logger.info("Linking transfer to request", { id, transferId }, MODULE_NAME);
+
+        await ApiService.post(
+            TRANSFER_REQUEST_ENDPOINTS.linkTransfer(id),
+            { transfer_id: transferId },
+        );
+
+        Logger.info("Transfer request linked and fulfilled", { id }, MODULE_NAME);
+    },
 };

--- a/src/modules/transfers/services/transferRequestService.ts
+++ b/src/modules/transfers/services/transferRequestService.ts
@@ -1,0 +1,75 @@
+import { ApiService } from "@/lib/apiService";
+import { Logger } from "@/lib/logger";
+import type {
+    CreateTransferRequestPayload,
+    FulfillDirectResult,
+    ImportResult,
+    TransferRequest,
+} from "../types/transferRequest.types";
+import { TRANSFER_REQUEST_ENDPOINTS } from "./transferRequestEndpoints.service";
+
+const MODULE_NAME = "TRANSFER_REQUEST_SERVICE";
+
+export const transferRequestService = {
+    /**
+     * Create a new transfer request
+     * @param data - Transfer request payload
+     */
+    async create(data: CreateTransferRequestPayload): Promise<TransferRequest> {
+        Logger.info("Creating Transfer Request", { data }, MODULE_NAME);
+
+        const response = await ApiService.post<TransferRequest>(
+            TRANSFER_REQUEST_ENDPOINTS.base,
+            data,
+        );
+
+        Logger.info("Transfer Request created successfully", undefined, MODULE_NAME);
+        return response;
+    },
+
+    /**
+     * Get a transfer request by ID
+     * @param id - Transfer request ID
+     */
+    async getById(id: number): Promise<TransferRequest> {
+        Logger.info("Fetching Transfer Request", { id }, MODULE_NAME);
+
+        const response = await ApiService.get<TransferRequest>(
+            TRANSFER_REQUEST_ENDPOINTS.byId(id),
+        );
+
+        Logger.info("Transfer Request fetched successfully", { id }, MODULE_NAME);
+        return response;
+    },
+
+    /**
+     * Fulfill a transfer request directly from stock
+     * @param id - Transfer request ID
+     */
+    async fulfillDirect(id: number): Promise<FulfillDirectResult> {
+        Logger.info("Fulfilling Transfer Request directly", { id }, MODULE_NAME);
+
+        const response = await ApiService.post<FulfillDirectResult>(
+            TRANSFER_REQUEST_ENDPOINTS.fulfillDirect(id),
+        );
+
+        Logger.info("Transfer Request fulfilled successfully", { id }, MODULE_NAME);
+        return response;
+    },
+
+    /**
+     * Import a transfer request — resolves lot data and transitions estado to IMPORTED.
+     * Uses POST because the call has a server-side state transition side effect.
+     * @param id - Transfer request ID
+     */
+    async import(id: number): Promise<ImportResult> {
+        Logger.info("Importing Transfer Request", { id }, MODULE_NAME);
+
+        const response = await ApiService.post<ImportResult>(
+            TRANSFER_REQUEST_ENDPOINTS.import(id),
+        );
+
+        Logger.info("Transfer Request imported successfully", { id }, MODULE_NAME);
+        return response;
+    },
+};

--- a/src/modules/transfers/services/transferRequestService.ts
+++ b/src/modules/transfers/services/transferRequestService.ts
@@ -43,6 +43,21 @@ export const transferRequestService = {
     },
 
     /**
+     * Dry-run FIFO check — returns what would be sent/adjusted/skipped without creating anything.
+     * @param id - Transfer request ID
+     */
+    async previewFulfillDirect(id: number): Promise<Pick<FulfillDirectResult, "fulfilled_items" | "skipped_items">> {
+        Logger.info("Previewing fulfill direct", { id }, MODULE_NAME);
+
+        const response = await ApiService.get<Pick<FulfillDirectResult, "fulfilled_items" | "skipped_items">>(
+            TRANSFER_REQUEST_ENDPOINTS.fulfillDirectPreview(id),
+        );
+
+        Logger.info("Preview fetched", { id }, MODULE_NAME);
+        return response;
+    },
+
+    /**
      * Fulfill a transfer request directly from stock
      * @param id - Transfer request ID
      */

--- a/src/modules/transfers/types/transferRequest.types.ts
+++ b/src/modules/transfers/types/transferRequest.types.ts
@@ -6,11 +6,11 @@ import type { ProductStock } from "@/modules/products/types/productStock";
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type TransferRequestEstado =
-  | "PENDING"
-  | "FULFILLED"
-  | "IMPORTED"
-  | "PARTIAL"
-  | "CANCELLED";
+  | "pending"
+  | "fulfilled"
+  | "imported"
+  | "partial"
+  | "cancelled";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ITEM TYPES

--- a/src/modules/transfers/types/transferRequest.types.ts
+++ b/src/modules/transfers/types/transferRequest.types.ts
@@ -9,6 +9,7 @@ export type TransferRequestEstado =
   | "pending"
   | "fulfilled"
   | "imported"
+  | "in_progress"
   | "partial"
   | "cancelled";
 

--- a/src/modules/transfers/types/transferRequest.types.ts
+++ b/src/modules/transfers/types/transferRequest.types.ts
@@ -73,6 +73,8 @@ export interface FulfilledItem {
   producto_id: number;
   producto_descripcion: string;
   cantidad: number;
+  cantidad_solicitada?: number;
+  was_partial?: boolean;
   lots_used: {
     almacen_id: number;
     lote: string;

--- a/src/modules/transfers/types/transferRequest.types.ts
+++ b/src/modules/transfers/types/transferRequest.types.ts
@@ -1,0 +1,114 @@
+import type { ProductGet } from "@/modules/products/types/ProductGet";
+import type { ProductStock } from "@/modules/products/types/productStock";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ESTADO (State Machine)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type TransferRequestEstado =
+  | "PENDING"
+  | "FULFILLED"
+  | "IMPORTED"
+  | "PARTIAL"
+  | "CANCELLED";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ITEM TYPES
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TransferRequestItem {
+  id: number;
+  producto_id: number;
+  producto_descripcion: string;
+  cantidad_solicitada: number;
+  cantidad_cumplida: number | null;
+}
+
+export interface CreateTransferRequestItem {
+  producto_id: number;
+  cantidad_solicitada: number;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CREATE (POST /transfer-requests)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CreateTransferRequestPayload {
+  sucursal_solicitante_id: number;
+  sucursal_destinataria_id: number;
+  usuario_destinatario_id: number;
+  items: CreateTransferRequestItem[];
+  notas?: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET (GET /transfer-requests/{id})
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TransferRequest {
+  id: number;
+  sucursal_solicitante_id: number;
+  sucursal_solicitante_nombre: string;
+  sucursal_destinataria_id: number;
+  sucursal_destinataria_nombre: string;
+  usuario_solicitante_id: number;
+  usuario_solicitante_nombre: string;
+  usuario_destinatario_id: number;
+  usuario_destinatario_nombre: string;
+  estado: TransferRequestEstado;
+  notas: string | null;
+  chat_message_id: number | null;
+  items: TransferRequestItem[];
+  created_at: string;
+  updated_at: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FULFILL DIRECT (POST /transfer-requests/{id}/fulfill-direct)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface FulfilledItem {
+  producto_id: number;
+  producto_descripcion: string;
+  cantidad: number;
+  lots_used: {
+    almacen_id: number;
+    lote: string;
+    fecha_ingreso: string;
+    cantidad: number;
+    costo: number;
+  }[];
+}
+
+export interface SkippedItem {
+  producto_id: number;
+  producto_descripcion: string;
+  cantidad_solicitada: number;
+  cantidad_disponible: number;
+  reason: "INSUFFICIENT_STOCK" | "NO_STOCK" | "PRODUCT_INACTIVE";
+}
+
+export interface FulfillDirectResult {
+  transfer_id: number | null;
+  request_estado: TransferRequestEstado;
+  fulfilled_items: FulfilledItem[];
+  skipped_items: SkippedItem[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IMPORT (POST /transfer-requests/{id}/import)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ImportResultItem {
+  producto_id: number;
+  product: ProductGet;
+  lots: ProductStock[];
+  cantidad_solicitada: number;
+}
+
+export interface ImportResult {
+  request_id: number;
+  sucursal_solicitante_id: number;
+  sucursal_destinataria_id: number;
+  items: ImportResultItem[];
+}

--- a/src/modules/transfers/types/transferRequest.types.ts
+++ b/src/modules/transfers/types/transferRequest.types.ts
@@ -58,6 +58,7 @@ export interface TransferRequest {
   estado: TransferRequestEstado;
   notas: string | null;
   chat_message_id: number | null;
+  product_transfer_id: number | null;
   items: TransferRequestItem[];
   created_at: string;
   updated_at: string;

--- a/src/navigation/Transfers.Route.ts
+++ b/src/navigation/Transfers.Route.ts
@@ -3,7 +3,8 @@ import CreateTransfer from "@/modules/transfers/screens/CreateTransfer";
 import EditTransfer from "@/modules/transfers/screens/EditTransfer";
 import TransferDetailScreen from "@/modules/transfers/screens/TransferDetailScreen";
 import TransferListScreen from "@/modules/transfers/screens/TransferListScreen";
-import { ArrowLeftRight, Package, Pencil, Shuffle, Table2 } from "lucide-react";
+import TransferRequestCreatePage from "@/modules/transfers/screens/TransferRequestCreatePage";
+import { ArrowLeftRight, Package, Pencil, Plus, Shuffle, Table2 } from "lucide-react";
 import type RouteType from "./RouteType";
 
 // Transferencias entre sucursales
@@ -42,6 +43,18 @@ const transfersProtectedRoutes: RouteType[] = [
         keepAlive: true,
         isHeader: false,
         showSidebar: true
+      },
+      {
+        path: "/dashboard/transfers/request/new",
+        name: "Nueva Solicitud de Transferencia",
+        type: "protected",
+        element: TransferRequestCreatePage,
+        isAdmin: false,
+        role: ["Administrador", "Vendedor", "Super Admin"],
+        icon: Plus,
+        isHeader: false,
+        showSidebar: true,
+        showInCommandPalette: true
       },
       {
         path: "/dashboard/transfers/:id",

--- a/src/navigation/Transfers.Route.ts
+++ b/src/navigation/Transfers.Route.ts
@@ -46,7 +46,7 @@ const transfersProtectedRoutes: RouteType[] = [
       },
       {
         path: "/dashboard/transfers/request/new",
-        name: "Nueva Solicitud de Transferencia",
+        name: "Solicitar Transferencia",
         type: "protected",
         element: TransferRequestCreatePage,
         isAdmin: false,

--- a/src/utils/imageCompression.ts
+++ b/src/utils/imageCompression.ts
@@ -181,6 +181,32 @@ export function calculateSavings(
   return Math.round(((originalSize - compressedSize) / originalSize) * 100);
 }
 
+/**
+ * Convierte un File a base64 data URL
+ */
+export function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Error leyendo el archivo"));
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Convierte un base64 data URL a un objeto File
+ */
+export function base64ToFile(base64Data: string, filename: string): File {
+  const arr = base64Data.split(",");
+  const mimeMatch = arr[0]?.match(/:(.*?);/);
+  const mime = mimeMatch ? mimeMatch[1] : "image/webp";
+  const bstr = atob(arr[1] ?? "");
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+  while (n--) u8arr[n] = bstr.charCodeAt(n);
+  return new File([u8arr], filename, { type: mime });
+}
+
 // Función pura sin estado
 export async function fetchImageAsBlobUrl(url: string): Promise<string> {
   const { fetch: tauriFetch } = await import("@tauri-apps/plugin-http");


### PR DESCRIPTION
## Summary

- New `TransferRequest` domain entity: users at branch A can request stock from users at branch B via chat
- `TransferRequestCreateScreen` — form with product picker + user picker, submits and sends a chat message with the request embedded
- `TransferRequestCard` — inline card inside `MessageBubble` for `referencia_tipo=transfer_request`; recipient gets action buttons (Importar / Enviar directo) gated by permission + terminal state checks
- Direct fulfillment flow: validates stock, creates transfer with available items, returns `FulfillDirectResult` (fulfilled vs skipped)
- Import flow: pre-fills `CreateTransfer` form via router state (`transferRequestPrefill`)

## Changes

| File | Change |
|------|--------|
| `src/modules/transfers/types/transferRequest.types.ts` | New — TransferRequest types and estado enum |
| `src/modules/transfers/schemas/transferRequest.schema.ts` | New — Zod validation schemas |
| `src/modules/transfers/services/transferRequestService.ts` | New — create/getById/fulfillDirect/import calls |
| `src/modules/transfers/hooks/use*.ts` | New — 4 hooks (create, byId, fulfill, import) |
| `src/modules/transfers/screens/TransferRequestCreate*.tsx` | New — create screen + route-level page wrapper |
| `src/modules/messaging/components/TransferRequestCard.tsx` | New — card component rendered inside MessageBubble |
| `src/modules/messaging/components/MessageBubble.tsx` | Added transfer_request branch |
| `src/modules/messaging/stores/ChatStore.ts` | Added sendTransferRequest() |
| `src/modules/messaging/types/Message.types.ts` | Added "transfer_request" to ReferenciaTipo |
| `src/modules/transfers/screens/CreateTransfer.tsx` | Reads router state for prefill |
| `src/navigation/Transfers.Route.ts` | Added /request/new route (static before /:id) |
| `src/lib/permissions.ts` | Added TRA.REQUEST_CREATE/VIEW/FULFILL/IMPORT |

## Test Plan

- [ ] Create a transfer request from the new screen — message appears in chat
- [ ] Recipient sees the card with action buttons; sender sees it read-only
- [ ] "Importar" → navigates to CreateTransfer with product rows pre-filled
- [ ] "Enviar directo" → confirm modal → result modal shows fulfilled/skipped items
- [ ] Terminal estados (FULFILLED, IMPORTED, CANCELLED) hide action buttons
- [ ] Permission-less recipient sees notice instead of buttons
- [ ] TypeScript: 0 errors