### PR TITLE
feat(sales): anticipo de pedido + fix forma_pago al editar venta

### DIFF
--- a/src/modules/sales/hooks/useDeleteSale.ts
+++ b/src/modules/sales/hooks/useDeleteSale.ts
@@ -20,6 +20,12 @@ export const useDeleteSale = () => {
       queryClient.invalidateQueries({
         queryKey: ["product-provider-orders"],
       });
+      // Anular una venta convertida reabre su cotización-pedido (convertida=false):
+      // refrescar cotizaciones para que el pedido reaparezca disponible.
+      queryClient.invalidateQueries({ queryKey: ["quotations"] });
+      // La anulación reversa movimientos de caja (saldo).
+      queryClient.invalidateQueries({ queryKey: ["cash-sessions"] });
+      queryClient.invalidateQueries({ queryKey: ["cash-session-active"] });
     },
     retry: false,
     networkMode: "offlineFirst",

--- a/src/modules/sales/schemas/sales.schema.ts
+++ b/src/modules/sales/schemas/sales.schema.ts
@@ -7,6 +7,7 @@ export const SalePaymentMethodSchema = z.object({
   vuelto: z.coerce.number().nonnegative().nullable().optional(),
   orden: z.coerce.number().int(),
   es_saldo: z.boolean().nullable().optional(),
+  es_anticipo: z.boolean().nullable().optional(),
 });
 
 export const SaleDetailSchema = z.object({

--- a/src/modules/sales/screens/createSaleScreen.tsx
+++ b/src/modules/sales/screens/createSaleScreen.tsx
@@ -64,13 +64,14 @@ import {
   ResizablePanelGroup,
 } from "@/components/atoms/resizable";
 import { Button } from "@/components/atoms/button";
+import { Badge } from "@/components/atoms/badge";
 import { useTabEffect } from "@/hooks/tabs/useTabEffect";
 import type { SelectedItem } from "@/types/windowSelectedItems";
 import CartModeConversionModal from "@/modules/shoppingCart/components/CartModeConversionModal";
 import { useFormEnterNavigation } from "@/hooks/useFormEnterNavigation";
 import { formatDateForSubmission, getTodayDate } from "@/utils/dateFormatters";
 import { useSalePaymentTypes } from "../hooks/useSalePaymentTypes";
-import { computePaymentBalance } from "../utils/paymentBalance";
+import { computePaymentBalance, resolvePaymentLabel } from "../utils/paymentBalance";
 import { useTabHotkeys } from "@/hooks/tabs/useTabHotkeys";
 import { useTabStore } from "@/states/tabStore";
 import { convertCartToSaleDetails } from "@/modules/shoppingCart/utils/cartCalculations";
@@ -333,6 +334,24 @@ const CreateSaleScreen = () => {
         setValue("comentario", formData.comentario);
       }
 
+      // Pedido con anticipo ya cobrado en la cotización: pre-cargar fila
+      // bloqueada (no editable, no removible). El backend relee el anticipo
+      // por cotizacion_id — esta fila es solo informativa para que el cajero
+      // vea que solo debe cobrar el saldo.
+      if (formData.anticipo && formData.anticipo > 0) {
+        setFormasPago((prev) => [
+          {
+            forma_pago: formData.forma_pago_anticipo ?? "",
+            monto: formData.anticipo,
+            monto_recibido: null,
+            vuelto: null,
+            orden: 1,
+            es_anticipo: true,
+          },
+          ...prev.map((item, i) => ({ ...item, orden: i + 2 })),
+        ]);
+      }
+
       // Limpiar el sessionStorage después de cargar
       sessionStorage.removeItem(storageKey);
 
@@ -585,10 +604,17 @@ const CreateSaleScreen = () => {
       return;
     }
 
+    // La fila es_anticipo es SOLO display en el FE: el backend re-inyecta el anticipo
+    // autoritativamente desde la cotización (server-side). Si la mandáramos en formas_pago,
+    // el backend la contaría como pago normal Y sumaría su propio anticipo → doble conteo.
+    const formasPagoToSend = formasPago.filter((fp) => !fp.es_anticipo);
+
     const dataToSend: Sale = {
       ...data,
       fecha: formatDateForSubmission(data.fecha),
-      ...(isContado && formasPago.length > 0 ? { formas_pago: formasPago } : {}),
+      ...(isContado && formasPagoToSend.length > 0
+        ? { formas_pago: formasPagoToSend }
+        : {}),
       cotizacion_id: sourceQuotation?.id ?? null,
     };
 
@@ -1237,108 +1263,133 @@ const CreateSaleScreen = () => {
                             </p>
                           )}
 
-                          {formasPago.map((fp, index) => (
-                            <div
-                              key={index}
-                              className="flex flex-wrap gap-2 items-end"
-                            >
-                              <div className="flex-1 min-w-[120px]">
-                                <Label className="text-xs">Forma de pago</Label>
-                                <Select
-                                  value={fp.forma_pago}
-                                  onValueChange={(value) => {
-                                    setFormasPago((prev) =>
-                                      prev.map((item, i) =>
-                                        i === index
-                                          ? {
-                                              ...item,
-                                              forma_pago: value,
-                                              monto_recibido:
-                                                value !== "EF"
-                                                  ? null
-                                                  : item.monto_recibido,
-                                            }
-                                          : item
-                                      )
-                                    );
-                                  }}
-                                >
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Selecciona" />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {salePaymentTypesData &&
-                                      salePaymentTypesData.map((pt) => (
-                                        <SelectItem key={pt.code} value={pt.code}>
-                                          {pt.label}
-                                        </SelectItem>
-                                      ))}
-                                  </SelectContent>
-                                </Select>
+                          {formasPago.map((fp, index) =>
+                            fp.es_anticipo ? (
+                              <div
+                                key={index}
+                                className="flex flex-wrap gap-2 items-center justify-between rounded-md border border-dashed border-emerald-400/50 bg-emerald-50/50 dark:bg-emerald-950/20 p-2"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <Badge
+                                    variant="success"
+                                    className="text-xs"
+                                  >
+                                    Adelanto ya cobrado
+                                  </Badge>
+                                  <span className="text-sm text-muted-foreground">
+                                    {resolvePaymentLabel(
+                                      fp.forma_pago,
+                                      salePaymentTypesData
+                                    )}
+                                  </span>
+                                </div>
+                                <span className="text-sm font-medium text-foreground">
+                                  Bs {fp.monto.toFixed(2)}
+                                </span>
                               </div>
+                            ) : (
+                              <div
+                                key={index}
+                                className="flex flex-wrap gap-2 items-end"
+                              >
+                                <div className="flex-1 min-w-[120px]">
+                                  <Label className="text-xs">Forma de pago</Label>
+                                  <Select
+                                    value={fp.forma_pago}
+                                    onValueChange={(value) => {
+                                      setFormasPago((prev) =>
+                                        prev.map((item, i) =>
+                                          i === index
+                                            ? {
+                                                ...item,
+                                                forma_pago: value,
+                                                monto_recibido:
+                                                  value !== "EF"
+                                                    ? null
+                                                    : item.monto_recibido,
+                                              }
+                                            : item
+                                        )
+                                      );
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Selecciona" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {salePaymentTypesData &&
+                                        salePaymentTypesData.map((pt) => (
+                                          <SelectItem key={pt.code} value={pt.code}>
+                                            {pt.label}
+                                          </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                  </Select>
+                                </div>
 
-                              <div className="flex-1 min-w-[100px]">
-                                <Label className="text-xs">Monto</Label>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step="0.01"
-                                  value={fp.monto === 0 ? "" : fp.monto}
-                                  onChange={(e) => {
-                                    const value = parseFloat(e.target.value) || 0;
-                                    setFormasPago((prev) =>
-                                      prev.map((item, i) =>
-                                        i === index ? { ...item, monto: value } : item
-                                      )
-                                    );
-                                  }}
-                                  placeholder="0.00"
-                                />
-                              </div>
-
-                              {fp.forma_pago === "EF" && (
                                 <div className="flex-1 min-w-[100px]">
-                                  <Label className="text-xs">Monto recibido</Label>
+                                  <Label className="text-xs">Monto</Label>
                                   <Input
                                     type="number"
                                     min={0}
                                     step="0.01"
-                                    value={fp.monto_recibido ?? ""}
+                                    value={fp.monto === 0 ? "" : fp.monto}
                                     onChange={(e) => {
-                                      const value =
-                                        e.target.value === ""
-                                          ? null
-                                          : parseFloat(e.target.value) || 0;
+                                      const value = parseFloat(e.target.value) || 0;
                                       setFormasPago((prev) =>
                                         prev.map((item, i) =>
-                                          i === index
-                                            ? { ...item, monto_recibido: value }
-                                            : item
+                                          i === index ? { ...item, monto: value } : item
                                         )
                                       );
                                     }}
                                     placeholder="0.00"
                                   />
                                 </div>
-                              )}
 
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="text-destructive hover:text-destructive"
-                                onClick={() =>
-                                  setFormasPago((prev) =>
-                                    prev
-                                      .filter((_, i) => i !== index)
-                                      .map((item, i) => ({ ...item, orden: i + 1 }))
-                                  )
-                                }
-                              >
-                                <Trash2 className="size-4" />
-                              </Button>
-                            </div>
-                          ))}
+                                {fp.forma_pago === "EF" && (
+                                  <div className="flex-1 min-w-[100px]">
+                                    <Label className="text-xs">Monto recibido</Label>
+                                    <Input
+                                      type="number"
+                                      min={0}
+                                      step="0.01"
+                                      value={fp.monto_recibido ?? ""}
+                                      onChange={(e) => {
+                                        const value =
+                                          e.target.value === ""
+                                            ? null
+                                            : parseFloat(e.target.value) || 0;
+                                        setFormasPago((prev) =>
+                                          prev.map((item, i) =>
+                                            i === index
+                                              ? { ...item, monto_recibido: value }
+                                              : item
+                                          )
+                                        );
+                                      }}
+                                      placeholder="0.00"
+                                    />
+                                  </div>
+                                )}
+
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className="text-destructive hover:text-destructive"
+                                  onClick={() =>
+                                    setFormasPago((prev) =>
+                                      prev
+                                        .filter((_, i) => i !== index)
+                                        .map((item, i) => ({ ...item, orden: i + 1 }))
+                                    )
+                                  }
+                                >
+                                  <Trash2 className="size-4" />
+                                </Button>
+                              </div>
+                            )
+                          )}
 
                           <div className="flex items-center justify-between pt-1">
                             <Button
@@ -1408,6 +1459,24 @@ const CreateSaleScreen = () => {
                             return (
                               <p className="text-xs text-emerald-600 dark:text-emerald-400">
                                 ✓ Pago completo
+                              </p>
+                            );
+                          })()}
+
+                          {/* Resumen de saldo a cobrar cuando hay anticipo aplicado */}
+                          {formasPago.some((fp) => fp.es_anticipo) && (() => {
+                            const balance = computePaymentBalance(
+                              formasPago,
+                              total,
+                              formValues.forma_pago,
+                              salePaymentTypesData
+                            );
+                            return (
+                              <p className="text-xs font-medium text-foreground pt-1 border-t border-border">
+                                Saldo a cobrar: Bs{" "}
+                                {balance.status === "pending"
+                                  ? balance.saldo.toFixed(2)
+                                  : "0.00"}
                               </p>
                             );
                           })()}

--- a/src/modules/sales/screens/saleEditScreen.tsx
+++ b/src/modules/sales/screens/saleEditScreen.tsx
@@ -68,7 +68,7 @@ import type { SaleGetById } from "../types/salesGetResponse";
 import type { ProductGet } from "@/modules/products/types/ProductGet";
 import type { SelectedItem } from "@/types/windowSelectedItems";
 import { useSalePaymentTypes } from "../hooks/useSalePaymentTypes";
-import { computePaymentBalance } from "../utils/paymentBalance";
+import { computePaymentBalance, resolvePaymentLabel } from "../utils/paymentBalance";
 import { useTabHotkeys } from "@/hooks/tabs/useTabHotkeys";
 import { PDFViewer } from "@/components/common/PDFViewer";
 import { useSalePDF } from "../hooks/useSalePDF";
@@ -270,7 +270,13 @@ const SaleEditScreen = () => {
       );
       const hasSaldoRow = sale.formas_pago_detalle.some((fp) => fp.es_saldo);
 
-      // Fila base implícita: una sola fila no-saldo, sin fila de saldo, y cuyo
+      // La fila es_anticipo NUNCA participa en el colapso de "fila base implícita":
+      // es un adelanto ya cobrado al convertir el pedido (ANTICIPO_COTIZACION), no
+      // un pago declarado por el cajero. Siempre debe sobrevivir, bloqueada.
+      const anticipoRows = nonSaldoRows.filter((fp) => fp.es_anticipo);
+      const editableRows = nonSaldoRows.filter((fp) => !fp.es_anticipo);
+
+      // Fila base implícita: una sola fila no-saldo/no-anticipo, sin fila de saldo, y cuyo
       // forma_pago coincide con el header. El backend la genera SIEMPRE (incluso
       // para ventas sin pago dividido real), por lo que cubre el total entero y
       // espeja el dropdown header. NO debe resucitarse como fila de split editable:
@@ -278,11 +284,14 @@ const SaleEditScreen = () => {
       // confía en formas_pago) y el movimiento de caja no se actualizaría.
       // Colapsándola, el header vuelve a ser la única fuente de verdad para el pago único.
       const isImplicitBase =
-        nonSaldoRows.length === 1 &&
+        editableRows.length === 1 &&
         !hasSaldoRow &&
-        nonSaldoRows[0].forma_pago === (sale.forma_pago ?? "");
+        editableRows[0].forma_pago === (sale.forma_pago ?? "");
 
-      setFormasPago(isImplicitBase ? [] : nonSaldoRows);
+      setFormasPago([
+        ...anticipoRows,
+        ...(isImplicitBase ? [] : editableRows),
+      ]);
     } else {
       setFormasPago([]);
     }
@@ -585,10 +594,17 @@ const SaleEditScreen = () => {
     const activeSale = saleData ?? tempCreatedSale;
     const hasCaja = activeSale?.caja_sesion_id != null;
 
+    // La fila es_anticipo es SOLO display en el FE: el backend re-inyecta el anticipo
+    // autoritativamente desde la cotización (server-side). Si la mandáramos en formas_pago,
+    // el backend la contaría como pago normal Y sumaría su propio anticipo → doble conteo.
+    const formasPagoToSend = formasPago.filter((fp) => !fp.es_anticipo);
+
     const dataToSend = {
       ...transformedData,
       fecha: fechaFormateada,
-      ...(hasCaja && formasPago.length > 0 ? { formas_pago: formasPago } : {}),
+      ...(hasCaja && formasPagoToSend.length > 0
+        ? { formas_pago: formasPagoToSend }
+        : {}),
     };
 
     updateSale(
@@ -1151,108 +1167,133 @@ const SaleEditScreen = () => {
                             </p>
                           )}
 
-                          {formasPago.map((fp, index) => (
-                            <div
-                              key={index}
-                              className="flex flex-wrap gap-2 items-end"
-                            >
-                              <div className="flex-1 min-w-[120px]">
-                                <Label className="text-xs">Forma de pago</Label>
-                                <Select
-                                  value={fp.forma_pago}
-                                  onValueChange={(value) => {
-                                    setFormasPago((prev) =>
-                                      prev.map((item, i) =>
-                                        i === index
-                                          ? {
-                                              ...item,
-                                              forma_pago: value,
-                                              monto_recibido:
-                                                value !== "EF"
-                                                  ? null
-                                                  : item.monto_recibido,
-                                            }
-                                          : item
-                                      )
-                                    );
-                                  }}
-                                >
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Selecciona" />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {salePaymentTypesData &&
-                                      salePaymentTypesData.map((pt) => (
-                                        <SelectItem key={pt.code} value={pt.code}>
-                                          {pt.label}
-                                        </SelectItem>
-                                      ))}
-                                  </SelectContent>
-                                </Select>
+                          {formasPago.map((fp, index) =>
+                            fp.es_anticipo ? (
+                              <div
+                                key={index}
+                                className="flex flex-wrap gap-2 items-center justify-between rounded-md border border-dashed border-emerald-400/50 bg-emerald-50/50 dark:bg-emerald-950/20 p-2"
+                              >
+                                <div className="flex items-center gap-2">
+                                  <Badge
+                                    variant="success"
+                                    className="text-xs"
+                                  >
+                                    Adelanto ya cobrado
+                                  </Badge>
+                                  <span className="text-sm text-muted-foreground">
+                                    {resolvePaymentLabel(
+                                      fp.forma_pago,
+                                      salePaymentTypesData
+                                    )}
+                                  </span>
+                                </div>
+                                <span className="text-sm font-medium text-foreground">
+                                  Bs {fp.monto.toFixed(2)}
+                                </span>
                               </div>
+                            ) : (
+                              <div
+                                key={index}
+                                className="flex flex-wrap gap-2 items-end"
+                              >
+                                <div className="flex-1 min-w-[120px]">
+                                  <Label className="text-xs">Forma de pago</Label>
+                                  <Select
+                                    value={fp.forma_pago}
+                                    onValueChange={(value) => {
+                                      setFormasPago((prev) =>
+                                        prev.map((item, i) =>
+                                          i === index
+                                            ? {
+                                                ...item,
+                                                forma_pago: value,
+                                                monto_recibido:
+                                                  value !== "EF"
+                                                    ? null
+                                                    : item.monto_recibido,
+                                              }
+                                            : item
+                                        )
+                                      );
+                                    }}
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Selecciona" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {salePaymentTypesData &&
+                                        salePaymentTypesData.map((pt) => (
+                                          <SelectItem key={pt.code} value={pt.code}>
+                                            {pt.label}
+                                          </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                  </Select>
+                                </div>
 
-                              <div className="flex-1 min-w-[100px]">
-                                <Label className="text-xs">Monto</Label>
-                                <Input
-                                  type="number"
-                                  min={0}
-                                  step="any"
-                                  value={fp.monto === 0 ? "" : fp.monto}
-                                  onChange={(e) => {
-                                    const value = parseFloat(e.target.value) || 0;
-                                    setFormasPago((prev) =>
-                                      prev.map((item, i) =>
-                                        i === index ? { ...item, monto: value } : item
-                                      )
-                                    );
-                                  }}
-                                  placeholder="0.00"
-                                />
-                              </div>
-
-                              {fp.forma_pago === "EF" && (
                                 <div className="flex-1 min-w-[100px]">
-                                  <Label className="text-xs">Monto recibido</Label>
+                                  <Label className="text-xs">Monto</Label>
                                   <Input
                                     type="number"
                                     min={0}
                                     step="any"
-                                    value={fp.monto_recibido ?? ""}
+                                    value={fp.monto === 0 ? "" : fp.monto}
                                     onChange={(e) => {
-                                      const value =
-                                        e.target.value === ""
-                                          ? null
-                                          : parseFloat(e.target.value) || 0;
+                                      const value = parseFloat(e.target.value) || 0;
                                       setFormasPago((prev) =>
                                         prev.map((item, i) =>
-                                          i === index
-                                            ? { ...item, monto_recibido: value }
-                                            : item
+                                          i === index ? { ...item, monto: value } : item
                                         )
                                       );
                                     }}
                                     placeholder="0.00"
                                   />
                                 </div>
-                              )}
 
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                className="text-destructive hover:text-destructive"
-                                onClick={() =>
-                                  setFormasPago((prev) =>
-                                    prev
-                                      .filter((_, i) => i !== index)
-                                      .map((item, i) => ({ ...item, orden: i + 1 }))
-                                  )
-                                }
-                              >
-                                <Trash2 className="size-4" />
-                              </Button>
-                            </div>
-                          ))}
+                                {fp.forma_pago === "EF" && (
+                                  <div className="flex-1 min-w-[100px]">
+                                    <Label className="text-xs">Monto recibido</Label>
+                                    <Input
+                                      type="number"
+                                      min={0}
+                                      step="any"
+                                      value={fp.monto_recibido ?? ""}
+                                      onChange={(e) => {
+                                        const value =
+                                          e.target.value === ""
+                                            ? null
+                                            : parseFloat(e.target.value) || 0;
+                                        setFormasPago((prev) =>
+                                          prev.map((item, i) =>
+                                            i === index
+                                              ? { ...item, monto_recibido: value }
+                                              : item
+                                          )
+                                        );
+                                      }}
+                                      placeholder="0.00"
+                                    />
+                                  </div>
+                                )}
+
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className="text-destructive hover:text-destructive"
+                                  onClick={() =>
+                                    setFormasPago((prev) =>
+                                      prev
+                                        .filter((_, i) => i !== index)
+                                        .map((item, i) => ({ ...item, orden: i + 1 }))
+                                    )
+                                  }
+                                >
+                                  <Trash2 className="size-4" />
+                                </Button>
+                              </div>
+                            )
+                          )}
 
                           <div className="flex items-center justify-between pt-1">
                             <Button
@@ -1322,6 +1363,24 @@ const SaleEditScreen = () => {
                             return (
                               <p className="text-xs text-emerald-600 dark:text-emerald-400">
                                 ✓ Pago completo
+                              </p>
+                            );
+                          })()}
+
+                          {/* Resumen de saldo a cobrar cuando hay anticipo aplicado */}
+                          {formasPago.some((fp) => fp.es_anticipo) && (() => {
+                            const balance = computePaymentBalance(
+                              formasPago,
+                              calculateTotal(),
+                              formValues.forma_pago,
+                              salePaymentTypesData
+                            );
+                            return (
+                              <p className="text-xs font-medium text-foreground pt-1 border-t border-border">
+                                Saldo a cobrar: Bs{" "}
+                                {balance.status === "pending"
+                                  ? balance.saldo.toFixed(2)
+                                  : "0.00"}
                               </p>
                             );
                           })()}

--- a/src/modules/sales/screens/saleEditScreen.tsx
+++ b/src/modules/sales/screens/saleEditScreen.tsx
@@ -265,7 +265,24 @@ const SaleEditScreen = () => {
     // Filter out es_saldo rows: buildFormasPago recomputes them fresh on save,
     // so they must never appear as explicit editable rows (avoids duplicate stacking on re-edit).
     if (sale.caja_sesion_id != null && sale.formas_pago_detalle?.length) {
-      setFormasPago(sale.formas_pago_detalle.filter((fp) => !fp.es_saldo));
+      const nonSaldoRows = sale.formas_pago_detalle.filter(
+        (fp) => !fp.es_saldo
+      );
+      const hasSaldoRow = sale.formas_pago_detalle.some((fp) => fp.es_saldo);
+
+      // Fila base implícita: una sola fila no-saldo, sin fila de saldo, y cuyo
+      // forma_pago coincide con el header. El backend la genera SIEMPRE (incluso
+      // para ventas sin pago dividido real), por lo que cubre el total entero y
+      // espeja el dropdown header. NO debe resucitarse como fila de split editable:
+      // si lo hiciéramos, cambiar el dropdown header no tendría efecto (el backend
+      // confía en formas_pago) y el movimiento de caja no se actualizaría.
+      // Colapsándola, el header vuelve a ser la única fuente de verdad para el pago único.
+      const isImplicitBase =
+        nonSaldoRows.length === 1 &&
+        !hasSaldoRow &&
+        nonSaldoRows[0].forma_pago === (sale.forma_pago ?? "");
+
+      setFormasPago(isImplicitBase ? [] : nonSaldoRows);
     } else {
       setFormasPago([]);
     }

--- a/src/modules/shoppingCart/utils/cartImportHelpers.ts
+++ b/src/modules/shoppingCart/utils/cartImportHelpers.ts
@@ -76,6 +76,11 @@ export interface QuotationFormData {
   vehiculo?: string;
   nro_motor?: string;
   comentario?: string;
+  /** Anticipo ya cobrado en la cotización-pedido. Se acredita al total de la venta
+   *  sin generar movimiento de caja nuevo (ya entró como ANTICIPO_COTIZACION). */
+  anticipo?: number;
+  /** Forma de pago con la que se cobró el anticipo (código PaymentTypes). */
+  forma_pago_anticipo?: string;
 }
 
 export const extractFormDataFromQuotation = (
@@ -93,6 +98,8 @@ export const extractFormDataFromQuotation = (
     vehiculo: quotation.vehiculo || undefined,
     nro_motor: quotation.nmotor || undefined,
     comentario: quotation.comentarios || undefined,
+    anticipo: quotation.anticipo || undefined,
+    forma_pago_anticipo: quotation.forma_pago_anticipo || undefined,
   };
 };
 


### PR DESCRIPTION
## Resumen

Dos cambios sobre el módulo de Ventas, listos para release:

### 1. fix(sales): forma_pago del header al editar pago único
Al editar una venta con un solo pago, el backend generaba una fila base que espejaba el header `forma_pago`. El FE la resucitaba como fila de split editable, por lo que cambiar el dropdown del header (ej. QR → EF) no tenía efecto y el movimiento de caja no se actualizaba. Ahora el header vuelve a ser la única fuente de verdad para el pago único.

### 2. feat(sales): venta a pedido con anticipo
Al convertir una cotización-pedido (con anticipo) en venta, el anticipo se acredita al total sin generar un nuevo movimiento de caja (ya ingresó como `ANTICIPO_COTIZACION` al recibirlo en la cotización). El cajero solo cobra el saldo.

- Precarga de una fila de pago bloqueada "Adelanto ya cobrado" al importar el pedido (create y edit).
- La fila `es_anticipo` cuenta al total pero se filtra antes de enviar (el backend la re-inyecta autoritativamente).
- Al anular una venta convertida se refrescan cotizaciones y caja (el pedido se reabre).

## Commits
- `266cf1f` fix(sales): respetar forma_pago del header al editar pago único
- `02474ff` feat(sales): mostrar y acreditar anticipo de pedido al convertir/editar venta
- `bfcec69` feat(sales): refrescar cotizaciones y caja al anular venta

## ⚠️ Dependencia de backend
Esta feature requiere el backend correspondiente (rama `feat/anticipo-venta-pedido` en api-commerce) **ya deployado y con la migración `es_anticipo` corrida**. Hacer el release del frontend SOLO después del deploy del backend.

## Verificación
- `npx tsc --noEmit` sin errores.
- Validado end-to-end en datos reales: conversión, edición, y anular + re-convertir → caja cuadra, anticipo entra una sola vez, sin doble conteo ni reversas espurias.