### PR TITLE
fix(quotations): hidratar sucursal seleccionada en ventana selector

### DIFF
--- a/src/modules/quotations/screens/quotationSelectorWindow.tsx
+++ b/src/modules/quotations/screens/quotationSelectorWindow.tsx
@@ -37,6 +37,7 @@ import type { QuotationGetAll } from "@/modules/quotations/types/quotationGet.ty
 import { useQuotationsPaginated } from "@/modules/quotations/hooks/useQuotationsPaginated";
 import { useSalesFilters } from "@/modules/sales/hooks/useSalesFilters";
 import { useBranchStore } from "@/states/branchStore";
+import authSDK from "@/services/sdk-simple-auth";
 import TooltipButton from "@/components/common/TooltipButton";
 import QuotationsFiltersComponent from "@/modules/quotations/components/quotationList/quotationFilterComponent";
 import { format } from "date-fns";
@@ -54,6 +55,14 @@ const QuotationSelectorWindow: React.FC = () => {
   const currentWindow = getCurrentWebviewWindow();
   const selectedBranchId = useBranchStore((s) => s.selectedBranchId);
   const tableRef = useRef<HTMLTableElement>(null);
+
+  // Hidratar el branch store desde localStorage — en ventanas secundarias de Tauri
+  // el store arranca con selectedBranchId: null porque restoreForUser() nunca se llama.
+  // authSDK.ready ya resolvió antes de este render (ver window-entry.tsx).
+  useEffect(() => {
+    const user = authSDK.getCurrentUser();
+    useBranchStore.getState().restoreForUser(user?.id ?? "");
+  }, []);
 
   const config: WindowConfig = useMemo(() => {
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Problema

La ventana secundaria de **seleccionar/importar cotizaciones** siempre traía datos de la sucursal `1` (central), sin importar la sucursal elegida en el topbar.

## Causa raíz

Las ventanas secundarias de Tauri son webviews separados (runtime JS independiente), así que el `branchStore` (Zustand sin persist) arranca con `selectedBranchId: null` porque `restoreForUser()` solo se llama en la ventana principal. Resultado:

```ts
useSalesFilters(Number(selectedBranchId) || 1) // Number(null)=0 → 0||1 = 1 → siempre central
```

## Fix

Hidratar el `branchStore` desde `localStorage` al montar la ventana, idéntico al patrón ya aplicado en `SaleDetailSelectorWindow.tsx`:

```ts
useEffect(() => {
  const user = authSDK.getCurrentUser();
  useBranchStore.getState().restoreForUser(user?.id ?? "");
}, []);
```

## Alcance

Solo `quotationSelectorWindow.tsx`. 

> ⚠️ **Nota:** El mismo bug existe en `OrderSelectorWindow`, `PurchaseSelectorWindow` y `ProductSelectorWindow` (este último con el matiz extra de que persiste `sucursal` en localStorage). Se abordarán por separado.