### PR TITLE
fix(transfers): usar precio del lote en transferencias + edición inline de precios

### DIFF
--- a/src/modules/products/components/productDetail/ProductInventory.tsx
+++ b/src/modules/products/components/productDetail/ProductInventory.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/atoms/card";
 import CustomizableTable from "@/components/common/CustomizableTable";
 import { type ColumnDef } from "@tanstack/react-table";
-import { Building2, Edit } from "lucide-react";
+import { Building2, Edit, Loader2, Save } from "lucide-react";
 import type { ProductStock } from "../../types/productStock";
 import { formatCurrency } from "@/utils/formaters";
 import { cn } from "@/lib/utils";
@@ -16,6 +16,10 @@ import { useMemo } from "react";
 import { useCustomTable } from "@/hooks/useCustomTable";
 import authSDK from "@/services/sdk-simple-auth";
 import { parseDateForUi } from "@/utils/dateFormatters";
+import { EditablePrice } from "@/modules/shoppingCart/components/editablePrice";
+import { usePermissionCheck } from "@/hooks/usePermissionCheck";
+import { PERMISSIONS } from "@/lib/permissions";
+import { useStockPriceDrafts } from "../../hooks/useInlineStockPriceUpdate";
 
 interface ProductInventoryProps {
   productStockData: ProductStock[];
@@ -37,6 +41,21 @@ const ProductInventory: React.FC<ProductInventoryProps> = ({
   onEditPrice,
 }) => {
   const user = authSDK.getCurrentUser();
+
+  // Edición inline de precios gateada por el permiso del endpoint update_prices
+  const { isAuthorized: canEditPrice } = usePermissionCheck({
+    permission: PERMISSIONS.COM.UPDATE_PRICES,
+    roles: [],
+    requireBoth: false,
+  });
+  const {
+    getFieldValue,
+    setDraftField,
+    dirtyCount,
+    discard,
+    save,
+    isSaving,
+  } = useStockPriceDrafts();
 
   // 🔥 Filtrar datos por stock si filterByStock = true
   const filteredData = useMemo(() => {
@@ -109,20 +128,70 @@ const ProductInventory: React.FC<ProductInventoryProps> = ({
       accessorKey: "precio_venta",
       header: `Precio Venta F.`,
       minSize: 30,
-      size: 80,
-      cell: ({ getValue }) => {
-        const value = getValue<number>();
-        return <div className="text-end">{formatCurrency(value)}</div>;
+      size: 90,
+      cell: ({ row }) => {
+        const detail = row.original;
+        if (!canEditPrice)
+          return (
+            <div className="text-end">{formatCurrency(detail.precio_venta)}</div>
+          );
+        const value = getFieldValue(detail, "precio_venta");
+        const changed = value !== detail.precio_venta;
+        return (
+          <EditablePrice
+            value={value}
+            onSubmit={(val) =>
+              setDraftField(
+                detail,
+                "precio_venta",
+                typeof val === "number" ? val : parseFloat(val.toString()) || 0
+              )
+            }
+            showEditIcon={false}
+            autoSelect
+            inputClassName="text-end"
+            buttonClassName={cn(
+              "justify-end",
+              changed && "text-amber-600 dark:text-amber-400 font-semibold"
+            )}
+          />
+        );
       },
     },
     {
       accessorKey: "precio_venta_alt",
       header: `Precio Venta Alt.`,
       minSize: 30,
-      size: 80,
-      cell: ({ getValue }) => {
-        const value = getValue<number>();
-        return <div className="text-end">{formatCurrency(value)}</div>;
+      size: 90,
+      cell: ({ row }) => {
+        const detail = row.original;
+        if (!canEditPrice)
+          return (
+            <div className="text-end">
+              {formatCurrency(detail.precio_venta_alt)}
+            </div>
+          );
+        const value = getFieldValue(detail, "precio_venta_alt");
+        const changed = value !== detail.precio_venta_alt;
+        return (
+          <EditablePrice
+            value={value}
+            onSubmit={(val) =>
+              setDraftField(
+                detail,
+                "precio_venta_alt",
+                typeof val === "number" ? val : parseFloat(val.toString()) || 0
+              )
+            }
+            showEditIcon={false}
+            autoSelect
+            inputClassName="text-end"
+            buttonClassName={cn(
+              "justify-end",
+              changed && "text-amber-600 dark:text-amber-400 font-semibold"
+            )}
+          />
+        );
       },
     },
     {
@@ -182,14 +251,16 @@ const ProductInventory: React.FC<ProductInventoryProps> = ({
       enableHiding: false,
       cell: ({ row }: { row: any }) => (
         <div className="flex justify-center">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => onEditPrice?.(row.original)}
-          >
-            <Edit className="h-4 w-4" />
-          </Button>
+          {canEditPrice && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => onEditPrice?.(row.original)}
+            >
+              <Edit className="h-4 w-4" />
+            </Button>
+          )}
         </div>
       ),
     },
@@ -224,13 +295,39 @@ const ProductInventory: React.FC<ProductInventoryProps> = ({
       )}
     >
       <CardHeader className="flex-shrink-0">
-        <CardTitle className="flex items-center gap-3 text-base font-semibold text-foreground">
-          <Building2 className="size-4 text-muted-foreground" />
-          Detalle disponibles en otras sucursales
+        <CardTitle className="flex items-center gap-2 text-base font-semibold text-foreground">
+          <Building2 className="size-4 text-muted-foreground shrink-0" />
+          <span className="truncate min-w-0">
+            Detalle disponibles en otras sucursales
+          </span>
           {filterByStock && (
-            <Badge variant="info" className="text-xs">
+            <Badge variant="info" className="text-xs shrink-0">
               Solo con stock
             </Badge>
+          )}
+          {canEditPrice && dirtyCount > 0 && (
+            <div className="ml-auto flex items-center gap-2 shrink-0">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={discard}
+                disabled={isSaving}
+              >
+                Cancelar
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => save(filteredData)}
+                disabled={isSaving}
+              >
+                {isSaving ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Save className="size-4" />
+                )}
+                Guardar ({dirtyCount})
+              </Button>
+            </div>
           )}
         </CardTitle>
       </CardHeader>

--- a/src/modules/products/components/productDetail/productTableOverview.tsx
+++ b/src/modules/products/components/productDetail/productTableOverview.tsx
@@ -10,12 +10,16 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/atoms/card";
-import { Edit, ShoppingCart } from "lucide-react";
+import { Edit, Loader2, Save, ShoppingCart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useMemo } from "react";
 import { useCustomTable } from "@/hooks/useCustomTable";
 import authSDK from "@/services/sdk-simple-auth";
 import { parseDateForUi } from "@/utils/dateFormatters";
+import { EditablePrice } from "@/modules/shoppingCart/components/editablePrice";
+import { usePermissionCheck } from "@/hooks/usePermissionCheck";
+import { PERMISSIONS } from "@/lib/permissions";
+import { useStockPriceDrafts } from "../../hooks/useInlineStockPriceUpdate";
 
 interface ProductTableOverviewProps {
   productStockData: ProductStock[];
@@ -39,6 +43,21 @@ const ProductTableOverview: React.FC<ProductTableOverviewProps> = ({
   onEditPrice,
 }) => {
   const user = authSDK.getCurrentUser();
+
+  // Edición inline de precios gateada por el permiso del endpoint update_prices
+  const { isAuthorized: canEditPrice } = usePermissionCheck({
+    permission: PERMISSIONS.COM.UPDATE_PRICES,
+    roles: [],
+    requireBoth: false,
+  });
+  const {
+    getFieldValue,
+    setDraftField,
+    dirtyCount,
+    discard,
+    save,
+    isSaving,
+  } = useStockPriceDrafts();
 
   // 🔥 Filtrar datos por stock si filterByStock = true
   const filteredData = useMemo(() => {
@@ -94,20 +113,71 @@ const ProductTableOverview: React.FC<ProductTableOverviewProps> = ({
       accessorKey: "precio_venta",
       header: `Precio Venta F.`,
       minSize: 30,
-      size: 80,
-      cell: ({ getValue }) => {
-        const value = getValue<number>();
-        return <div className="text-end">{formatCurrency(value)}</div>;
+      size: 90,
+      cell: ({ row }) => {
+        const detail = row.original;
+        if (!canEditPrice)
+          return (
+            <div className="text-end">{formatCurrency(detail.precio_venta)}</div>
+          );
+        const value = getFieldValue(detail, "precio_venta");
+        const changed = value !== detail.precio_venta;
+        return (
+          <EditablePrice
+            value={value}
+            onSubmit={(val) =>
+              setDraftField(
+                detail,
+                "precio_venta",
+                typeof val === "number" ? val : parseFloat(val.toString()) || 0
+              )
+            }
+            showEditIcon={false}
+            autoSelect
+            inputClassName="text-end"
+            buttonClassName={cn(
+              "justify-end",
+              changed && "text-amber-600 dark:text-amber-400 font-semibold"
+            )}
+          />
+        );
       },
     },
     {
       accessorKey: "precio_venta_alt",
       header: `Precio Venta Alt.`,
       minSize: 30,
-      size: 80,
-      cell: ({ getValue }) => (
-        <div className="text-end">{formatCurrency(getValue<number>())}</div>
-      ),
+      size: 90,
+      cell: ({ row }) => {
+        const detail = row.original;
+        if (!canEditPrice)
+          return (
+            <div className="text-end">
+              {formatCurrency(detail.precio_venta_alt)}
+            </div>
+          );
+        const value = getFieldValue(detail, "precio_venta_alt");
+        const changed = value !== detail.precio_venta_alt;
+        return (
+          <EditablePrice
+            value={value}
+            onSubmit={(val) =>
+              setDraftField(
+                detail,
+                "precio_venta_alt",
+                typeof val === "number" ? val : parseFloat(val.toString()) || 0
+              )
+            }
+            showEditIcon={false}
+            autoSelect
+            inputClassName="text-end"
+            buttonClassName={cn(
+              "justify-end",
+              changed && "text-amber-600 dark:text-amber-400 font-semibold"
+            )}
+          />
+        );
+      },
     },
     {
       accessorKey: "tc_compra",
@@ -188,14 +258,16 @@ const ProductTableOverview: React.FC<ProductTableOverviewProps> = ({
       enableHiding: false,
       cell: ({ row }: { row: any }) => (
         <div className="flex justify-center">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            onClick={() => onEditPrice?.(row.original)}
-          >
-            <Edit className="h-4 w-4" />
-          </Button>
+          {canEditPrice && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => onEditPrice?.(row.original)}
+            >
+              <Edit className="h-4 w-4" />
+            </Button>
+          )}
         </div>
       ),
     },
@@ -231,16 +303,42 @@ const ProductTableOverview: React.FC<ProductTableOverviewProps> = ({
     >
       <CardHeader className="flex-shrink-0">
         <CardTitle className="flex items-center justify-between gap-3 text-base font-semibold text-foreground">
-          <span className="flex items-center gap-2">
-            <ShoppingCart className="size-4 text-muted-foreground" />
-            Compras Disponibles
+          <span className="flex items-center gap-2 min-w-0">
+            <ShoppingCart className="size-4 text-muted-foreground shrink-0" />
+            <span className="truncate">Compras Disponibles</span>
             {filterByStock && (
-              <Badge variant="info" className="text-xs ml-2">
+              <Badge variant="info" className="text-xs ml-2 shrink-0">
                 Solo con stock
               </Badge>
             )}
           </span>
-          <Badge variant="secondary">Stock Total: {stockTotal}</Badge>
+          <div className="flex items-center gap-2 shrink-0">
+            {canEditPrice && dirtyCount > 0 && (
+              <>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={discard}
+                  disabled={isSaving}
+                >
+                  Cancelar
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => save(filteredData)}
+                  disabled={isSaving}
+                >
+                  {isSaving ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Save className="size-4" />
+                  )}
+                  Guardar ({dirtyCount})
+                </Button>
+              </>
+            )}
+            <Badge variant="secondary">Stock Total: {stockTotal}</Badge>
+          </div>
         </CardTitle>
       </CardHeader>
       <CardContent className="flex-1 min-h-0">

--- a/src/modules/products/hooks/useInlineStockPriceUpdate.ts
+++ b/src/modules/products/hooks/useInlineStockPriceUpdate.ts
@@ -1,0 +1,148 @@
+import { useCallback, useState } from "react";
+import { useUpdatePurchaseDetailPrices } from "@/modules/purchases/hooks/useUpdatePurchaseDetailPrices";
+import { showErrorToast, showSuccessToast } from "@/hooks/use-toast-enhanced";
+import {
+  dividePrecise,
+  multiplyPrecise,
+  roundTo5Decimals,
+} from "@/utils/decimalUtils";
+import type { UpdatePurchaseDetailPricesFormData } from "@/modules/purchases/types/UpdatePurchaseDetailPrices.types";
+import type { ProductStock } from "../types/productStock";
+
+// Margen porcentual de `final` sobre `base` — misma fórmula que useUpdatePriceForm,
+// para que el payload sea idéntico al del modal y el backend no recalcule distinto.
+const calcIncrement = (base: number, final: number): number => {
+  if (base === 0) return 0;
+  return multiplyPrecise(dividePrecise(final - base, base), 100);
+};
+
+export type PriceField = "precio_venta" | "precio_venta_alt";
+
+interface PriceDraft {
+  precio_venta?: number;
+  precio_venta_alt?: number;
+}
+
+// Arma el payload de update_prices para UN lote. El costo NUNCA se envía:
+// solo se usa como base para el incremento. detalles = [id] → corrección quirúrgica.
+const buildPayload = (
+  detail: ProductStock,
+  draft: PriceDraft
+): UpdatePurchaseDetailPricesFormData => {
+  const precio_venta = roundTo5Decimals(
+    draft.precio_venta ?? detail.precio_venta
+  );
+  const precio_venta_alt = roundTo5Decimals(
+    draft.precio_venta_alt ?? detail.precio_venta_alt
+  );
+  return {
+    precio_venta,
+    precio_venta_alt,
+    incremento_p_venta: calcIncrement(detail.costo, precio_venta),
+    incremento_p_venta_alt: calcIncrement(precio_venta, precio_venta_alt),
+    detalles: [detail.id],
+  };
+};
+
+const draftIsEmpty = (detail: ProductStock, draft: PriceDraft): boolean => {
+  const pv = draft.precio_venta ?? detail.precio_venta;
+  const pva = draft.precio_venta_alt ?? detail.precio_venta_alt;
+  return (
+    roundTo5Decimals(pv) === roundTo5Decimals(detail.precio_venta) &&
+    roundTo5Decimals(pva) === roundTo5Decimals(detail.precio_venta_alt)
+  );
+};
+
+/**
+ * Borrador local de precios para edición inline en las tablas de stock del
+ * detalle de producto. Los cambios NO pegan al API hasta que se llama a
+ * `save()` — evita guardados accidentales por blur. Cada lote se persiste con
+ * `detalles: [id]` (corrección de un solo lote).
+ */
+export const useStockPriceDrafts = () => {
+  const { mutateAsync, isPending } = useUpdatePurchaseDetailPrices();
+  const [drafts, setDrafts] = useState<Record<number, PriceDraft>>({});
+
+  // Valor a mostrar en la celda: el del borrador si existe, si no el original.
+  const getFieldValue = useCallback(
+    (detail: ProductStock, field: PriceField): number =>
+      drafts[detail.id]?.[field] ?? detail[field],
+    [drafts]
+  );
+
+  const setDraftField = useCallback(
+    (detail: ProductStock, field: PriceField, value: number) => {
+      setDrafts((prev) => {
+        const next: PriceDraft = { ...prev[detail.id], [field]: value };
+        // Si vuelve al valor original en ambos campos, descartamos el borrador.
+        if (draftIsEmpty(detail, next)) {
+          const { [detail.id]: _omit, ...rest } = prev;
+          return rest;
+        }
+        return { ...prev, [detail.id]: next };
+      });
+    },
+    []
+  );
+
+  const isDirty = useCallback((id: number): boolean => id in drafts, [drafts]);
+
+  const dirtyCount = Object.keys(drafts).length;
+
+  const discard = useCallback(() => setDrafts({}), []);
+
+  // Guarda todos los borradores. Un lote = una llamada (cada lote tiene su precio).
+  const save = useCallback(
+    async (details: ProductStock[]) => {
+      const byId = new Map(details.map((d) => [d.id, d]));
+      const entries = Object.entries(drafts);
+      if (entries.length === 0) return;
+
+      const results = await Promise.allSettled(
+        entries.map(([id, draft]) => {
+          const detail = byId.get(Number(id));
+          if (!detail) return Promise.resolve();
+          return mutateAsync(buildPayload(detail, draft));
+        })
+      );
+
+      const failed = results.filter((r) => r.status === "rejected").length;
+      const ok = results.length - failed;
+
+      if (ok > 0) {
+        showSuccessToast({
+          title: "Precios actualizados",
+          description: `${ok} lote(s) actualizado(s)${
+            failed > 0 ? `, ${failed} con error` : ""
+          }`,
+        });
+      }
+      if (failed > 0 && ok === 0) {
+        showErrorToast({
+          title: "Error al actualizar precios",
+          description: `No se pudo actualizar ${failed} lote(s)`,
+        });
+      }
+
+      // Limpiamos solo los que se guardaron bien; los que fallaron quedan en borrador.
+      setDrafts((prev) => {
+        const next = { ...prev };
+        entries.forEach(([id], i) => {
+          if (results[i].status === "fulfilled") delete next[Number(id)];
+        });
+        return next;
+      });
+    },
+    [drafts, mutateAsync]
+  );
+
+  return {
+    getFieldValue,
+    setDraftField,
+    isDirty,
+    dirtyCount,
+    discard,
+    save,
+    isSaving: isPending,
+  };
+};

--- a/src/modules/transfers/hooks/useTransferDetails.ts
+++ b/src/modules/transfers/hooks/useTransferDetails.ts
@@ -20,13 +20,16 @@ export const useTransferDetails = (
                 const totalSaldo = lots.reduce((sum, lot) => sum + lot.saldo, 0);
                 const oldestLot = lots[0];
 
+                // El precio de venta se toma del LOTE (precio real por compra), no del
+                // precio maestro del producto. El maestro puede diferir del precio editado
+                // por lote y provocaba que la transferencia arrastrara un precio viejo.
                 const newRow: UITransferDetailCreate = {
                     producto_id: product.id,
                     cantidad_entrada_salida: totalSaldo,
                     costo_entrada: oldestLot.costo,
-                    precio_salida: product.precio_venta,
-                    precio_entrada_venta: product.precio_venta,
-                    precio_entrada_venta_alt: product.precio_venta_alt,
+                    precio_salida: oldestLot.precio_venta,
+                    precio_entrada_venta: oldestLot.precio_venta,
+                    precio_entrada_venta_alt: oldestLot.precio_venta_alt,
                     incremento_p_entrada_venta: 0,
                     incremento_p_entrada_venta_alt: 0,
                     tc_transfer: oldestLot.tc_compra || tcTransfer,
@@ -40,8 +43,8 @@ export const useTransferDetails = (
                         codigo_upc: product.codigo_upc,
                         marca: product.marca || null,
                         costo: oldestLot.costo,
-                        precio_venta: product.precio_venta,
-                        precio_venta_alt: product.precio_venta_alt,
+                        precio_venta: oldestLot.precio_venta,
+                        precio_venta_alt: oldestLot.precio_venta_alt,
                     },
                 };
                 return [...prev, newRow];
@@ -194,6 +197,11 @@ export const useTransferDetails = (
                     ...base,
                     cantidad_entrada_salida: take,
                     costo_entrada: lot.costo,
+                    // Fidelidad por lote (B puro): cada lote viaja con SU precio de venta,
+                    // no con el precio agregado del producto.
+                    precio_salida: lot.precio_venta,
+                    precio_entrada_venta: lot.precio_venta,
+                    precio_entrada_venta_alt: lot.precio_venta_alt,
                     tc_transfer: lot.tc_compra || base.tc_transfer,
                     fecha_adquisicion: lot.fecha_adquisicion,
                 });

--- a/src/modules/transfers/screens/CreateTransfer.tsx
+++ b/src/modules/transfers/screens/CreateTransfer.tsx
@@ -79,8 +79,11 @@ const buildPrefillRows = (prefill: ImportResult): UITransferDetailCreate[] =>
     const totalSaldo = lotsAsc.reduce((sum, lot) => sum + lot.saldo, 0);
     const oldestLot = lotsAsc[0];
     const product = item.product;
-    const precioVenta = Number(product.precio_venta ?? oldestLot.precio_venta) || 0;
-    const precioVentaAlt = Number(product.precio_venta_alt ?? oldestLot.precio_venta_alt) || 0;
+    // Precio por LOTE, no el maestro del producto (B puro): el precio real de
+    // la transferencia sale del lote. getTransferDetails vuelve a pisar por lote
+    // al partir FIFO; esta semilla solo alimenta el display del row agregado.
+    const precioVenta = Number(oldestLot.precio_venta ?? product.precio_venta) || 0;
+    const precioVentaAlt = Number(oldestLot.precio_venta_alt ?? product.precio_venta_alt) || 0;
     return [
       {
         producto_id: Number(product.id),


### PR DESCRIPTION
## Problema

Al crear una transferencia entre sucursales, el **precio de venta** de la mercadería llegaba con un valor incorrecto: tomaba el **precio maestro del producto** en vez del **precio real del lote**.

Caso real del cliente (transferencia `TRA-CT-1770`): un lote con costo `Bs 167,46` que en la central se vendía a **`Bs 385,15`** se transfirió a la sucursal con **`Bs 489,50`** (el precio maestro del producto), cuando debía conservar el precio del lote.

## Causa raíz

En `useTransferDetails.ts`, al armar el detalle de la transferencia:

- `getTransferDetails` **sí** pisaba `costo_entrada` y `tc_transfer` por lote al partir FIFO,
- pero **no** el precio de venta: arrastraba `precio_entrada_venta` = `product.precio_venta` (maestro), sembrado en `addProduct`.

Confirmado con la data real: en el detalle de `TRA-CT-1770` la columna **"Precio Entrada" = 489,50**, o sea el **frontend enviaba el precio equivocado**; el backend solo guardaba lo recibido. No requiere cambios de backend.

## Fix

**1. Transferencias — precio por lote (B puro)**
Cada fila FIFO ahora toma `precio_salida` / `precio_entrada_venta` / `precio_entrada_venta_alt` del **lote**, igual que ya hacía con costo y TC. La semilla en `addProduct` y el prefill del flujo de import también usan el lote. `EditTransfer` queda cubierto sin cambios (los detalles guardados entran sin `lots` y pasan derecho).

**2. Corrección de lotes ya afectados — edición inline de precios**
Las columnas **Precio Venta** y **Precio Venta Alt.** de las tablas de stock del modal de detalle de producto ahora son editables inline, con **borrador local + botón Guardar/Cancelar** (no guarda por blur). Reusa el endpoint existente `update_prices` con `detalles:[id]` (un lote por vez). El **costo no se toca**. Se agregó gate de permiso `com-update_prices`, que antes **no se aplicaba** en el frontend (la edición de precios estaba abierta).

## Cambios

| Archivo | Cambio |
|---|---|
| `src/modules/transfers/hooks/useTransferDetails.ts` | Precio de venta por lote en `getTransferDetails` y semilla en `addProduct` |
| `src/modules/transfers/screens/CreateTransfer.tsx` | Prefill de import usa el precio del lote |
| `src/modules/products/hooks/useInlineStockPriceUpdate.ts` | Nuevo: `useStockPriceDrafts` (borrador + guardado explícito por lote) |
| `src/modules/products/components/productDetail/ProductInventory.tsx` | Celdas de precio editables + botón Guardar/Cancelar + gate permiso |
| `src/modules/products/components/productDetail/productTableOverview.tsx` | Ídem para la tabla de sucursal actual |

## Test plan

- [ ] Transferir un lote con precio editado → llega con el **precio del lote**, no el maestro
- [ ] En el detalle de la transferencia, "Precio Entrada" = precio del lote
- [ ] Editar precio inline en el modal → celda ámbar → **Guardar** persiste y refresca; **Cancelar** descarta
- [ ] Sin permiso `com-update_prices` → celdas read-only y sin botón de edición

> Nota: no se corrió build (regla del proyecto). Validar en dev antes de release.
