### PR TITLE
chore(release): sincronizar bump de versión 1.8.0 a development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tps-intermotors",
   "private": true,
-  "version": "1.7.4",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "1.7.4"
+version = "1.8.0"
 description = "A Tauri App"
 authors = ["StackOverlords"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Intermotors",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "identifier": "com.intermotors.tps",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Qué hace

Trae a `development` el commit de bump de versión (`baf9926`) generado al cortar el release **1.8.0**, que quedó solo en la rama feature.

## Por qué

El release 1.8.0 se cortó desde esta rama (tags `v1.8.0-t1/t2` + GH Releases ya publicados), pero el commit de bump nunca volvió a `development`, que sigue en `1.7.4`. Sin esto, el próximo release calcularía mal la versión y chocaría contra tags ya existentes (patch→1.7.5 y minor→1.8.0 ya están tomados).

Es el mismo hueco de proceso que dejó el bump de 1.7.5 sin volver a development. Este PR lo cierra.

## Cambios

| Archivo | Cambio |
|---------|--------|
| `package.json` | version 1.7.4 → 1.8.0 |
| `src-tauri/tauri.conf.json` | version 1.7.4 → 1.8.0 |
| `src-tauri/Cargo.toml` | version 1.7.4 → 1.8.0 |

## Verificación

- Diff de 3 puntos (base merge `41a5695`) contiene **solo** los 3 archivos de versión.
- `git merge-tree` confirma que NO se revierte el código de #280 (transfers/products): para esos archivos el commit es idéntico al merge-base, el merge 3-way conserva lo de development.

Post-merge: `development` queda en 1.8.0 y el próximo release computa 1.8.1.