### PR TITLE
fix(sales): reindexar orden al agregar y quitar productos del detalle

### DIFF
--- a/src/modules/sales/hooks/useSaleProductDetails.ts
+++ b/src/modules/sales/hooks/useSaleProductDetails.ts
@@ -45,6 +45,11 @@ interface UseSaleProductDetailsReturn {
   setGlobalDiscount: (discount: number) => void;
 }
 
+// Reasigna `orden` secuencialmente. El backend ordena por (orden, id), asi que
+// las filas deben quedar sin huecos ni repetidos al agregar o quitar productos.
+const reindexOrden = (details: SaleUpdateDetailUI[]): SaleUpdateDetailUI[] =>
+  details.map((detail, index) => ({ ...detail, orden: index + 1 }));
+
 const useSaleProductDetailsWithForm = ({
   formMethods,
   originalDetails = [],
@@ -498,7 +503,7 @@ const useSaleProductDetailsWithForm = ({
         }
       });
 
-      setValue("detalles", updated);
+      setValue("detalles", reindexOrden(updated));
       showToastSummary(input, addedCount, skippedCount, productsToAdd);
     },
     [setValue, getValues, hasDiscount, getAvailableStock, calculateItemDiscount, getRealQuantity]
@@ -521,7 +526,7 @@ const useSaleProductDetailsWithForm = ({
       const updated = currentProducts.filter(
         (detail) => detail.producto?.id !== productId
       );
-      setValue("detalles", updated);
+      setValue("detalles", reindexOrden(updated));
     },
     [setValue, getValues]
   );
@@ -628,7 +633,7 @@ const useSaleProductDetailsWithForm = ({
         }
       });
 
-      setValue("detalles", updated);
+      setValue("detalles", reindexOrden(updated));
 
       if (addedCount > 0) {
         showSuccessToast({


### PR DESCRIPTION
## Problema

En el detalle de venta, el campo `orden` se corrompía de dos formas:

1. **Agregado múltiple**: `orden: currentProducts.length + 1` estaba **dentro del `forEach`**, leyendo `currentProducts`, que no muta durante el loop. Agregar N productos de una vez les asignaba **el mismo `orden` a todos**.
2. **`removeProduct` no reindexaba**: al quitar una fila quedaban huecos, y el siguiente producto agregado podía colisionar con un `orden` ya existente.

Esto importa porque los usuarios cargan los ítems siguiendo una lista que les pasa el cliente, y ese orden tiene que sobrevivir.

## Cambios

| Archivo | Cambio |
|---|---|
| `src/modules/sales/hooks/useSaleProductDetails.ts` | helper `reindexOrden` aplicado en los tres `setValue("detalles", ...)`: agregado simple, `removeProduct` y agregado múltiple con cantidad |

Es el mismo patrón que ya usa `useOrderDetails.ts` (`.map((d, i) => ({ ...d, orden: i + 1 }))`), así que queda consistente entre módulos.

## Relación con el backend

Este cambio es el par frontend de **rhleone/api-commerce#13**, que agrega `->orderBy('orden')->orderBy('id')` a las relaciones `detalles()`. Los dos son independientes y no se bloquean entre sí:

- Sin el backend, este fix igual evita generar `orden` duplicados hacia adelante.
- El desempate por `id` del backend cubre los registros históricos.

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` → 0 errores en el archivo modificado. El repo arrastra errores de tipos preexistentes en otros archivos (`chart.tsx`, `form.tsx`, `sidebar.tsx`), ajenos a este cambio.
- **Pendiente de validación en UI**: no se verificó en pantalla el comportamiento de agregar/quitar múltiple.
