### PR TITLE
feat(order-cart): carrito de pedido desde el listado de productos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Diagnosticos generados por Module Federation (se regeneran en cada build)
+.mf/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/modules/orderCart/components/OrderCartBadgeButton.tsx
+++ b/src/modules/orderCart/components/OrderCartBadgeButton.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { Badge } from "@/components/atoms/badge";
+import { Button } from "@/components/atoms/button";
+import { ShoppingCart } from "lucide-react";
+import { useOrderCart } from "../hooks/useOrderCart";
+import { OrderCartSheet } from "./OrderCartSheet";
+
+/**
+ * Trigger + badge de conteo + panel, autocontenido (mismo espíritu que
+ * `NotificationsPanel`: el que lo monta no necesita manejar estado de
+ * apertura). Oculto cuando `count === 0` o `!isReady` (sin scope
+ * resuelto todavía — ver design D2).
+ */
+export const OrderCartBadgeButton: React.FC = () => {
+  const { count, isReady } = useOrderCart();
+  const [open, setOpen] = useState(false);
+
+  if (!isReady || count === 0) return null;
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="relative size-8 cursor-pointer"
+        onClick={() => setOpen(true)}
+      >
+        <ShoppingCart className="h-4 w-4" />
+        <Badge
+          variant="destructive"
+          className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-xs"
+        >
+          {count}
+        </Badge>
+      </Button>
+
+      <OrderCartSheet open={open} onOpenChange={setOpen} />
+    </>
+  );
+};
+
+export default OrderCartBadgeButton;

--- a/src/modules/orderCart/components/OrderCartItemRow.tsx
+++ b/src/modules/orderCart/components/OrderCartItemRow.tsx
@@ -1,0 +1,125 @@
+import { Badge } from "@/components/atoms/badge";
+import { Button } from "@/components/atoms/button";
+import { Checkbox } from "@/components/atoms/checkbox";
+import { Label } from "@/components/atoms/label";
+import { EditableField } from "@/components/common/EditableField";
+import { formatDate } from "@/utils/formaters";
+import { Trash2, TriangleAlert } from "lucide-react";
+import type { OrderCartItem } from "../types/orderCart.types";
+
+interface OrderCartItemRowProps {
+  item: OrderCartItem;
+  selected?: boolean;
+  /**
+   * Cuando no se provee, la fila no muestra checkbox. Es el modo por
+   * defecto: el traspaso trae el carrito completo, así que no hay nada
+   * que tildar.
+   */
+  onToggleSelect?: (productId: number) => void;
+  onUpdateCantidad: (productId: number, cantidad: number) => void;
+  onRemove: (productId: number) => void;
+}
+
+/**
+ * Fila de solo props — no toca el store. `OrderCartSheet` (el consumidor)
+ * es quien lee `useOrderCart()` y le pasa acá item + callbacks, igual que
+ * `cartItemComponent.tsx` en el carrito de ventas.
+ */
+export const OrderCartItemRow: React.FC<OrderCartItemRowProps> = ({
+  item,
+  selected = false,
+  onToggleSelect,
+  onUpdateCantidad,
+  onRemove,
+}) => {
+  const { product, cantidad, addedAt } = item;
+
+  const warnings: string[] = [];
+  if (product.pedido_transito > 0) {
+    warnings.push(`Ya hay ${product.pedido_transito} en camino`);
+  }
+  if (product.pedido_almacen > 0) {
+    warnings.push(`Ya hay ${product.pedido_almacen} en almacén`);
+  }
+
+  return (
+    <div className="border-border rounded-lg p-1.5 border">
+      <div className="flex items-start gap-2">
+        {onToggleSelect && (
+          <Checkbox
+            className="mt-1"
+            checked={selected}
+            onCheckedChange={() => onToggleSelect(product.id)}
+          />
+        )}
+
+        <div className="flex-1">
+          <h4 className="text-xs font-medium text-foreground mb-1">
+            {product.descripcion}
+          </h4>
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            <Badge variant="secondary" className="text-[10px]">
+              {product.codigo_oem}
+            </Badge>
+            <span className="text-[10px] text-muted-foreground">
+              {product.marca}
+            </span>
+            <Badge variant="outline" className="text-[10px]">
+              Stock: {product.stock_actual}
+            </Badge>
+            <span className="text-[10px] text-muted-foreground">
+              Agregado: {formatDate(addedAt)}
+            </span>
+          </div>
+
+          {warnings.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-2">
+              {warnings.map((warning) => (
+                <Badge
+                  key={warning}
+                  variant="warning"
+                  className="text-[10px] gap-1"
+                >
+                  <TriangleAlert className="size-3" />
+                  {warning}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="max-w-[120px]">
+            <Label className="text-xs text-foreground mb-1">Cantidad</Label>
+            <EditableField
+              type="number"
+              value={cantidad}
+              numberProps={{ min: 1, step: 1 }}
+              formatter={(value) => value.toString()}
+              focusNextOnEnter
+              className="w-full"
+              buttonClassName="w-full"
+              validate={(val) => {
+                const num = parseInt(val, 10);
+                return !isNaN(num) && num > 0;
+              }}
+              onSubmit={(value) =>
+                onUpdateCantidad(product.id, value as number)
+              }
+            />
+          </div>
+        </div>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onRemove(product.id)}
+          className="text-red-500 hover:text-red-500 size-7 dark:text-red-400 dark:hover:text-red-400"
+        >
+          <Trash2 className="size-3" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default OrderCartItemRow;

--- a/src/modules/orderCart/components/OrderCartSheet.tsx
+++ b/src/modules/orderCart/components/OrderCartSheet.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/atoms/button";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/atoms/sheet";
+import { BrushCleaning, ListChecks, ShoppingCart, Truck, X } from "lucide-react";
+import { useOrderCart } from "../hooks/useOrderCart";
+import { OrderCartItemRow } from "./OrderCartItemRow";
+
+interface OrderCartSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Cuando se provee, agrega una acción de traspaso en el footer.
+   * Este componente NO sabe nada de pedidos/`useOrderDetails` — solo
+   * entrega el subconjunto de ids seleccionados. `OrderCartTransferButton`
+   * es quien la usa para exponer esa selección hacia `orderCreateScreen`.
+   */
+  onTransferSelected?: (selectedIds: number[]) => void;
+  transferLabel?: string;
+  /**
+   * Habilita el tildado ítem por ítem. Apagado por defecto: el traspaso
+   * normal es "traer todo" de un click, y obligar a seleccionar uno por uno
+   * duplica el trabajo. Se conserva detrás del flag
+   * `seedFromOrderCartSelective` para un posible uso futuro.
+   */
+  allowSelective?: boolean;
+}
+
+/**
+ * Panel del carrito de pedido: lista, edición de cantidad, remove-one,
+ * "vaciar carrito" y checkbox de selección por ítem (para el traspaso).
+ * Selector-based: consume `useOrderCart()` acá arriba y le pasa a cada
+ * `OrderCartItemRow` solo lo que necesita — la fila no toca el store.
+ */
+export const OrderCartSheet: React.FC<OrderCartSheetProps> = ({
+  open,
+  onOpenChange,
+  onTransferSelected,
+  transferLabel = "Traer al pedido",
+  allowSelective = false,
+}) => {
+  const { items, updateCantidad, removeItem, clear } = useOrderCart();
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (!open) setSelectedIds(new Set());
+  }, [open]);
+
+  const toggleSelect = (productId: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(productId)) next.delete(productId);
+      else next.add(productId);
+      return next;
+    });
+  };
+
+  const handleTransferSelected = () => {
+    if (!onTransferSelected || selectedIds.size === 0) return;
+    onTransferSelected(Array.from(selectedIds));
+    setSelectedIds(new Set());
+  };
+
+  const handleTransferAll = () => {
+    if (!onTransferSelected || items.length === 0) return;
+    onTransferSelected(items.map((item) => item.product.id));
+    setSelectedIds(new Set());
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        hasButtonClose={false}
+        className="w-[400px] sm:w-[500px] h-full sm:h-[98vh] sm:mr-2 sm:my-auto sm:rounded-lg flex flex-col p-3 gap-2"
+      >
+        <SheetHeader className="flex flex-col flex-shrink-0">
+          <SheetTitle className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ShoppingCart className="w-5 h-5" />
+              Carrito de pedido
+            </div>
+            <div className="flex items-center gap-2">
+              {items.length > 0 && (
+                <Button
+                  type="button"
+                  className="cursor-pointer"
+                  onClick={clear}
+                  variant="destructive"
+                >
+                  <BrushCleaning />
+                  Vaciar carrito
+                </Button>
+              )}
+              <SheetClose className="size-8 rounded-sm ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary flex items-center justify-center">
+                <X className="w-4 h-4" />
+              </SheetClose>
+            </div>
+          </SheetTitle>
+          <SheetDescription className="-mt-2 text-left">
+            {items.length} producto{items.length === 1 ? "" : "s"} en el
+            carrito
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          {items.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground h-full flex flex-col justify-center items-center">
+              <ShoppingCart className="w-12 h-12 mx-auto mb-4 opacity-50" />
+              <p>El carrito de pedido está vacío</p>
+            </div>
+          ) : (
+            <div className="overflow-y-auto h-full flex flex-col gap-2">
+              {items.map((item) => (
+                <OrderCartItemRow
+                  key={`order-cart-item-${item.product.id}`}
+                  item={item}
+                  selected={selectedIds.has(item.product.id)}
+                  onToggleSelect={allowSelective ? toggleSelect : undefined}
+                  onUpdateCantidad={updateCantidad}
+                  onRemove={removeItem}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {onTransferSelected && items.length > 0 && (
+          <SheetFooter className="flex-shrink-0 border-t border-border pt-2 flex flex-col gap-2">
+            <Button
+              type="button"
+              className="w-full cursor-pointer"
+              onClick={handleTransferAll}
+            >
+              <Truck />
+              {transferLabel} todo ({items.length})
+            </Button>
+
+            {allowSelective && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full cursor-pointer"
+                disabled={selectedIds.size === 0}
+                onClick={handleTransferSelected}
+              >
+                <ListChecks />
+                Traer seleccionados ({selectedIds.size})
+              </Button>
+            )}
+          </SheetFooter>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+export default OrderCartSheet;

--- a/src/modules/orderCart/components/OrderCartTransferButton.tsx
+++ b/src/modules/orderCart/components/OrderCartTransferButton.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { Button } from "@/components/atoms/button";
+import { Truck } from "lucide-react";
+import { useOrderCart } from "../hooks/useOrderCart";
+import { OrderCartSheet } from "./OrderCartSheet";
+
+interface OrderCartTransferButtonProps {
+  /**
+   * Recibe el subconjunto de ids a traer. Este componente NO conoce
+   * `useOrderDetails` ni el contrato de detalle de pedido — la lógica de
+   * traspaso (mapeo `{ ...product, quantity: cantidad }`,
+   * `addMultipleProducts`, `removeMany`) vive en `orderCreateScreen`
+   * (Fase 3, defect compensations 1 y 2).
+   */
+  onTransfer: (selectedIds: number[]) => void;
+  /**
+   * Habilita el tildado ítem por ítem dentro del panel. Apagado por
+   * defecto: la acción normal es "traer todo" de un click desde el panel.
+   * Se conserva detrás del flag `seedFromOrderCartSelective`.
+   */
+  allowSelective?: boolean;
+  className?: string;
+}
+
+/**
+ * "Traer del carrito (N)" — pensado para montarse en `orderCreateScreen`.
+ * Oculto cuando el carrito no está listo o está vacío.
+ *
+ * Abre `OrderCartSheet`, donde el usuario ve qué hay acumulado y lo trae
+ * todo de un click. La selección por ítem vive detrás de `allowSelective`.
+ */
+export const OrderCartTransferButton: React.FC<
+  OrderCartTransferButtonProps
+> = ({ onTransfer, allowSelective = false, className }) => {
+  const { count, isReady } = useOrderCart();
+  const [open, setOpen] = useState(false);
+
+  if (!isReady || count === 0) return null;
+
+  return (
+    <>
+      <Button
+        // El componente se monta DENTRO del <form> de orderCreateScreen. Sin
+        // type="button" el default de HTML es "submit" y abrir el panel
+        // dispararia la validacion del formulario.
+        type="button"
+        variant="outline"
+        size="sm"
+        className={className}
+        onClick={() => setOpen(true)}
+      >
+        <Truck className="h-4 w-4" />
+        Traer del carrito ({count})
+      </Button>
+
+      <OrderCartSheet
+        open={open}
+        onOpenChange={setOpen}
+        transferLabel="Traer al pedido"
+        allowSelective={allowSelective}
+        onTransferSelected={(selectedIds) => {
+          onTransfer(selectedIds);
+          setOpen(false);
+        }}
+      />
+    </>
+  );
+};
+
+export default OrderCartTransferButton;

--- a/src/modules/orderCart/constants/orderCart.constants.ts
+++ b/src/modules/orderCart/constants/orderCart.constants.ts
@@ -1,0 +1,5 @@
+export const ORDER_CART_CONSTANTS = {
+  ORDER_CART_STORAGE_PREFIX: "order-cart-",
+} as const;
+
+export const { ORDER_CART_STORAGE_PREFIX } = ORDER_CART_CONSTANTS;

--- a/src/modules/orderCart/hooks/useOrderCart.ts
+++ b/src/modules/orderCart/hooks/useOrderCart.ts
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import { useStore } from "zustand";
+import { useOrderCartScope } from "./useOrderCartScope";
+import {
+  getOrCreateOrderCartStore,
+  NULL_ORDER_CART,
+} from "../store/orderCartRegistry";
+import type { OrderCartItem } from "../types/orderCart.types";
+
+export interface UseOrderCartResult {
+  items: OrderCartItem[];
+  /** Cantidad de líneas distintas en el carrito (no la suma de cantidades). */
+  count: number;
+  isReady: boolean;
+  addItem: (product: OrderCartItem["product"], cantidad?: number) => void;
+  addMany: (products: OrderCartItem["product"][], cantidad?: number) => void;
+  updateCantidad: (productId: number, cantidad: number) => void;
+  removeItem: (productId: number) => void;
+  removeMany: (productIds: number[]) => void;
+  clear: () => void;
+}
+
+/**
+ * Facade del carrito de pedido. Sin argumentos: resuelve el scope
+ * (usuario+sucursal) internamente vía `useOrderCartScope` — así ningún
+ * call site puede llavear mal el carrito (el defecto de `useCartWithUtils`
+ * con `user.name`, ver design D2).
+ *
+ * `useMemo` acá guarda la IDENTIDAD del store (no el costo de crearlo) —
+ * sin él, cada render pediría una instancia "nueva" al registry y
+ * `useStore` perdería la suscripción entre renders.
+ *
+ * Scope `null` (sin usuario o sin sucursal, incluida la ventana de
+ * hidratación async del auth) → `NULL_ORDER_CART`: vacío, no persistido,
+ * `isReady: false`, acciones no-op.
+ */
+export function useOrderCart(): UseOrderCartResult {
+  const scopeKey = useOrderCartScope();
+
+  const store = useMemo(
+    () => (scopeKey ? getOrCreateOrderCartStore(scopeKey) : NULL_ORDER_CART),
+    [scopeKey],
+  );
+
+  const items = useStore(store, (s) => s.items);
+  const isReady = useStore(store, (s) => s.isReady);
+  const addItem = useStore(store, (s) => s.addItem);
+  const addMany = useStore(store, (s) => s.addMany);
+  const updateCantidad = useStore(store, (s) => s.updateCantidad);
+  const removeItem = useStore(store, (s) => s.removeItem);
+  const removeMany = useStore(store, (s) => s.removeMany);
+  const clear = useStore(store, (s) => s.clear);
+
+  return {
+    items,
+    count: items.length,
+    isReady,
+    addItem,
+    addMany,
+    updateCantidad,
+    removeItem,
+    removeMany,
+    clear,
+  };
+}

--- a/src/modules/orderCart/hooks/useOrderCartScope.ts
+++ b/src/modules/orderCart/hooks/useOrderCartScope.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import authSDK from "@/services/sdk-simple-auth";
+import { useBranchStore } from "@/states/branchStore";
+
+function buildScopeKey(
+  userId: string | undefined,
+  branchId: string | null,
+): string | null {
+  if (!userId || !branchId) return null;
+  return `u${userId}-b${branchId}`;
+}
+
+/**
+ * Resuelve el scope (usuario id + sucursal id) del carrito de pedido.
+ *
+ * Llavear por `id`, no por `name` — a diferencia de `useCartWithUtils`
+ * (carrito de ventas), que llavea por `user.name` y por eso homónimos
+ * comparten carrito. Acá el hook resuelve el scope INTERNAMENTE: no recibe
+ * user/branch por argumentos, así el call site no puede pasarlos mal.
+ *
+ * Reactivo a `authSDK.onAuthStateChanged` (mismo patrón que
+ * `useUserRole.ts` / `useShowTabBar.ts`) para cubrir la ventana de
+ * hidratación async del SDK (storage indexedDB): en el primer render
+ * `getCurrentUser()` puede devolver `null` aunque haya sesión persistida,
+ * y sin esta suscripción el scope quedaría pegado en `null`.
+ *
+ * `null` cuando no hay usuario o no hay sucursal seleccionada todavía —
+ * el consumidor (`useOrderCart`) debe caer a `NULL_ORDER_CART` en ese caso.
+ */
+export function useOrderCartScope(): string | null {
+  const branchId = useBranchStore((state) => state.selectedBranchId);
+  const [scopeKey, setScopeKey] = useState<string | null>(() =>
+    buildScopeKey(authSDK.getCurrentUser()?.id, branchId),
+  );
+
+  useEffect(() => {
+    setScopeKey(buildScopeKey(authSDK.getCurrentUser()?.id, branchId));
+
+    const unsubscribe = authSDK.onAuthStateChanged((authState) => {
+      setScopeKey(buildScopeKey(authState.user?.id, branchId));
+    });
+
+    return () => unsubscribe();
+    // branchId es dependencia intencional: al cambiar de sucursal el scope
+    // debe re-derivarse aunque no cambie el estado de auth.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [branchId]);
+
+  return scopeKey;
+}

--- a/src/modules/orderCart/store/orderCartRegistry.ts
+++ b/src/modules/orderCart/store/orderCartRegistry.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+import {
+  createOrderCartStore,
+  type OrderCartStoreInstance,
+} from "./orderCartStore";
+import type { OrderCartStore } from "../types/orderCart.types";
+
+/**
+ * Registry módulo-nivel: una instancia de store por scope (usuario+sucursal).
+ * Mirrors `CartManager` (`shoppingCart/services/cartManager.ts`), sin la
+ * ceremonia de clase/singleton — un `Map` alcanza.
+ */
+const stores = new Map<string, OrderCartStoreInstance>();
+
+export const getOrCreateOrderCartStore = (
+  scopeKey: string,
+): OrderCartStoreInstance => {
+  const existing = stores.get(scopeKey);
+  if (existing) return existing;
+
+  const created = createOrderCartStore(scopeKey);
+  stores.set(scopeKey, created);
+  return created;
+};
+
+/**
+ * Store "nulo" para cuando el scope no está resuelto (sin usuario o sin
+ * sucursal — incluye la ventana de hidratación async del auth SDK).
+ * `isReady: false`, vacío, no persistido (sin middleware `persist`), y con
+ * acciones no-op: escribir acá no debe crear la falsa sensación de que el
+ * item quedó guardado en algún lado.
+ */
+export const NULL_ORDER_CART: OrderCartStoreInstance = create<OrderCartStore>()(
+  () => ({
+    items: [],
+    isReady: false,
+    addItem: () => {},
+    addMany: () => {},
+    updateCantidad: () => {},
+    removeItem: () => {},
+    removeMany: () => {},
+    clear: () => {},
+  }),
+);

--- a/src/modules/orderCart/store/orderCartStore.ts
+++ b/src/modules/orderCart/store/orderCartStore.ts
@@ -1,0 +1,104 @@
+import { create } from "zustand";
+import type { StoreApi, UseBoundStore } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+import { ORDER_CART_STORAGE_PREFIX } from "../constants/orderCart.constants";
+import type { OrderCartItem, OrderCartStore } from "../types/orderCart.types";
+
+type PersistedOrderCart = Pick<OrderCartStore, "items">;
+
+/**
+ * Store por scope (usuario+sucursal). Factory, no singleton — cada
+ * `scopeKey` obtiene su propia instancia y su propia key de localStorage,
+ * a cargo del registry (`orderCartRegistry.ts`).
+ */
+export const createOrderCartStore = (scopeKey: string) =>
+  create<OrderCartStore>()(
+    devtools(
+      persist(
+        (set, get) => ({
+          items: [],
+          isReady: true,
+
+          addItem: (product, cantidad = 1) => {
+            get().addMany([product], cantidad);
+          },
+
+          addMany: (products, cantidad = 1) => {
+            let items = get().items;
+
+            products.forEach((product) => {
+              const existing = items.find((i) => i.product.id === product.id);
+
+              items = existing
+                ? items.map((i) =>
+                    i.product.id === product.id
+                      ? { ...i, cantidad: i.cantidad + cantidad }
+                      : i,
+                  )
+                : [
+                    ...items,
+                    {
+                      product,
+                      cantidad,
+                      addedAt: new Date().toISOString(),
+                    } satisfies OrderCartItem,
+                  ];
+            });
+
+            set({ items });
+          },
+
+          updateCantidad: (productId, cantidad) => {
+            if (!Number.isFinite(cantidad) || cantidad <= 0) return;
+
+            set({
+              items: get().items.map((i) =>
+                i.product.id === productId ? { ...i, cantidad } : i,
+              ),
+            });
+          },
+
+          removeItem: (productId) => {
+            set({
+              items: get().items.filter((i) => i.product.id !== productId),
+            });
+          },
+
+          removeMany: (productIds) => {
+            const idsToRemove = new Set(productIds);
+            set({
+              items: get().items.filter((i) => !idsToRemove.has(i.product.id)),
+            });
+          },
+
+          clear: () => set({ items: [] }),
+        }),
+        {
+          name: `${ORDER_CART_STORAGE_PREFIX}${scopeKey}`,
+          storage: createJSONStorage(() => localStorage),
+          partialize: (state): PersistedOrderCart => ({ items: state.items }),
+          version: 1,
+          merge: (persistedState, currentState) => {
+            const persisted = persistedState as Partial<PersistedOrderCart> | undefined;
+            const items = (persisted?.items ?? []).filter(
+              (item): item is OrderCartItem => Boolean(item?.product?.id),
+            );
+
+            return { ...currentState, items };
+          },
+        },
+      ),
+      { name: `order-cart-${scopeKey}` },
+    ),
+  );
+
+/**
+ * Tipo de instancia de store, deliberadamente el bound-store SIN los
+ * extras de middleware (`.persist`, devtools). `NULL_ORDER_CART`
+ * (`orderCartRegistry.ts`) es un store plano sin middleware — tipar acá
+ * con `ReturnType<typeof createOrderCartStore>` (que sí incluye esos
+ * extras) rompería esa asignación. Todo consumidor solo necesita
+ * `getState`/`setState`/`subscribe` + el call-signature de hook, que es
+ * exactamente lo que expone este tipo.
+ */
+export type OrderCartStoreInstance = UseBoundStore<StoreApi<OrderCartStore>>;

--- a/src/modules/orderCart/types/orderCart.types.ts
+++ b/src/modules/orderCart/types/orderCart.types.ts
@@ -1,0 +1,41 @@
+import type { ProductGet } from "@/modules/products/types/ProductGet";
+
+/**
+ * Línea del carrito de pedido: snapshot del producto (no solo el id) +
+ * cantidad acumulada + fecha de alta. Sin campos de precio/costo — esa
+ * derivación es responsabilidad exclusiva de `useOrderDetails` al momento
+ * del traspaso, no del carrito.
+ */
+export interface OrderCartItem {
+  product: ProductGet;
+  cantidad: number;
+  /** ISO timestamp — habilita el aviso de antigüedad en el panel */
+  addedAt: string;
+}
+
+export interface OrderCartState {
+  items: OrderCartItem[];
+  /**
+   * `false` únicamente en `NULL_ORDER_CART` (scope sin resolver: sin
+   * usuario o sin sucursal, incluida la ventana de hidratación async del
+   * auth). Los stores reales creados por `createOrderCartStore` siempre
+   * nacen con `isReady: true` — si el scope no está resuelto, no se crea
+   * store real.
+   */
+  isReady: boolean;
+}
+
+export interface OrderCartActions {
+  /** Si el producto ya está en el carrito, suma `cantidad` en vez de crear una segunda línea. */
+  addItem: (product: ProductGet, cantidad?: number) => void;
+  /** Igual que `addItem` pero para una tanda (alta masiva desde selección múltiple). */
+  addMany: (products: ProductGet[], cantidad?: number) => void;
+  /** Ignora valores `<= 0` o `NaN` — la línea queda con la cantidad anterior. */
+  updateCantidad: (productId: number, cantidad: number) => void;
+  removeItem: (productId: number) => void;
+  /** Usado en el traspaso a pedido: limpia únicamente el subconjunto transferido. */
+  removeMany: (productIds: number[]) => void;
+  clear: () => void;
+}
+
+export type OrderCartStore = OrderCartState & OrderCartActions;

--- a/src/modules/orders/config/order.config.ts
+++ b/src/modules/orders/config/order.config.ts
@@ -174,6 +174,18 @@ export const ordersListViewConfig: ViewConfiguration = {
       label: 'Ayuda de Filtros',
       description: 'Mostrar tooltip con atajos de filtros',
     },
+
+    seedFromOrderCart: {
+      enabled: true,
+      label: 'Traer del Carrito de Pedido',
+      description: 'Permitir transferir productos del carrito de pedido al crear un pedido',
+    },
+
+    seedFromOrderCartSelective: {
+      enabled: false,
+      label: 'Selección individual al traer del Carrito de Pedido',
+      description: 'Agrega un botón para elegir qué productos traer en vez de traer el carrito completo. Desactivado: en la práctica se trae todo de una',
+    },
   },
 
   behaviors: {

--- a/src/modules/orders/screens/orderCreateScreen.tsx
+++ b/src/modules/orders/screens/orderCreateScreen.tsx
@@ -32,7 +32,10 @@ import TooltipButton from "@/components/common/TooltipButton";
 import { showErrorToast, showSuccessToast } from "@/hooks/use-toast-enhanced";
 import { useErrorHandler } from "@/hooks/useErrorHandler";
 import { useProductSelectorWindow } from "@/hooks/useSecondaryWindow";
+import { useViewConfig } from "@/hooks/useViewConfig";
 import { cn } from "@/lib/utils";
+import { OrderCartTransferButton } from "@/modules/orderCart/components/OrderCartTransferButton";
+import { useOrderCart } from "@/modules/orderCart/hooks/useOrderCart";
 import type { ProductGet } from "@/modules/products/types/ProductGet";
 import authSDK from "@/services/sdk-simple-auth";
 import { useBranchStore } from "@/states/branchStore";
@@ -99,6 +102,9 @@ const OrderCreateScreen = () => {
 
   // Hook de detalles de orden (pasar exchangeRate)
   const orderDetailsHook = useOrderDetails(false, exchangeRate);
+
+  const { isFeatureEnabled } = useViewConfig("orders-list");
+  const orderCart = useOrderCart();
 
   const { data: orderTypesData } = useOrderTypes();
 
@@ -319,6 +325,44 @@ const OrderCreateScreen = () => {
         tableRef.current?.focusQuantityInputByProductId(products[0].id);
       }
     }, 100);
+  };
+
+  // Traer productos seleccionados desde el carrito de pedido (orderCart)
+  const handleSeedFromOrderCart = (selectedIds: number[]) => {
+    const selectedItems = orderCart.items.filter((item) =>
+      selectedIds.includes(item.product.id)
+    );
+
+    if (selectedItems.length === 0) return;
+
+    // [DEFECT COMPENSATION 1] useOrderDetails.ts:141 hace
+    // `cantidad: product.quantity` SIN `?? 1` en la rama de ítem nuevo (a
+    // diferencia de la rama de merge, que sí lo tiene). Pasar el `product`
+    // crudo sin `quantity` explícito dejaría `cantidad: undefined`.
+    const payload = selectedItems.map((item) => ({
+      ...item.product,
+      quantity: item.cantidad,
+    }));
+
+    const addedProductIds = orderDetailsHook.addMultipleProducts(payload);
+
+    setTimeout(() => {
+      // Enfocar el primer producto nuevo que se agregó (mismo patrón que
+      // handleAddMultipleProducts)
+      if (addedProductIds.length > 0) {
+        tableRef.current?.focusQuantityInputByProductId(addedProductIds[0]);
+      } else if (payload.length > 0) {
+        tableRef.current?.focusQuantityInputByProductId(payload[0].id);
+      }
+    }, 100);
+
+    // [DEFECT COMPENSATION 2] `addedProductIds` (useOrderDetails.ts:166) solo
+    // incluye ids agregados por la rama de ítem NUEVO — un producto que ya
+    // estaba en el pedido se mergea pero su id nunca se retorna. Vaciar el
+    // carrito por `addedProductIds` dejaría colgado ese producto mergeado.
+    // Se vacía por el subconjunto SELECCIONADO, que sí llega completo al
+    // pedido (nuevo o mergeado).
+    orderCart.removeMany(selectedIds);
   };
 
   const onSubmit = (data: OrderCreate) => {
@@ -957,18 +1001,29 @@ const OrderCreateScreen = () => {
                             </div>
 
                             {/* Botón de acción - Derecha */}
-                            {configuraciones.selector_mode === "window" && (
-                              <Button
-                                type="button"
-                                onClick={toggleWindowSelector}
-                                disabled={isSaving}
-                              >
-                                <Plus className="size-4" />
-                                <span className="hidden sm:block">
-                                  Seleccionar Productos
-                                </span>
-                              </Button>
-                            )}
+                            <div className="flex items-center gap-2">
+                              {isFeatureEnabled("seedFromOrderCart") && (
+                                <OrderCartTransferButton
+                                  onTransfer={handleSeedFromOrderCart}
+                                  allowSelective={isFeatureEnabled(
+                                    "seedFromOrderCartSelective"
+                                  )}
+                                />
+                              )}
+
+                              {configuraciones.selector_mode === "window" && (
+                                <Button
+                                  type="button"
+                                  onClick={toggleWindowSelector}
+                                  disabled={isSaving}
+                                >
+                                  <Plus className="size-4" />
+                                  <span className="hidden sm:block">
+                                    Seleccionar Productos
+                                  </span>
+                                </Button>
+                              )}
+                            </div>
                           </CardTitle>
                         </CardHeader>
                         <CardContent className="flex-1 min-h-0">

--- a/src/modules/products/config/product.config.ts
+++ b/src/modules/products/config/product.config.ts
@@ -91,6 +91,18 @@ export const productsListViewConfig: ViewConfiguration = {
       description: 'Agregar productos seleccionados al carrito',
     },
 
+    addToOrderCart: {
+      enabled: true,
+      label: 'Agregar a Pedido',
+      description: 'Agregar el producto al carrito de pedido',
+    },
+
+    bulkAddToOrderCart: {
+      enabled: true,
+      label: 'Agregar Múltiples a Pedido',
+      description: 'Agregar productos seleccionados al carrito de pedido',
+    },
+
     viewImage: {
       enabled: true,
       label: 'Ver Imagen',

--- a/src/modules/products/screens/ProductListScreen.tsx
+++ b/src/modules/products/screens/ProductListScreen.tsx
@@ -31,6 +31,8 @@ import { COMMANDS, useCommands, useKeybindingKeys } from "@/keybindings";
 import { QuickTransferRequestModal } from "@/modules/transfers/components/QuickTransferRequestModal";
 import BottomShoppingCartBar from "@/modules/shoppingCart/components/BottomShoppingCartBar";
 import { useCartWithUtils } from "@/modules/shoppingCart/hooks/useCartWithUtils";
+import { OrderCartBadgeButton } from "@/modules/orderCart/components/OrderCartBadgeButton";
+import { useOrderCart } from "@/modules/orderCart/hooks/useOrderCart";
 import authSDK from "@/services/sdk-simple-auth";
 import { useBranchStore } from "@/states/branchStore";
 import { formatCell } from "@/utils/formatCell";
@@ -38,6 +40,7 @@ import { formatCurrency } from "@/utils/formaters";
 import { type ColumnDef } from "@tanstack/react-table";
 import {
   ArrowLeftRight,
+  ClipboardList,
   Edit,
   Eye,
   HelpCircle,
@@ -188,6 +191,8 @@ const ProductListScreen = () => {
   const { addItemToCart, addMultipleItems, decrementQuantity } =
     useCartWithUtils(user?.name ?? "", selectedBranchId ?? "");
 
+  const orderCart = useOrderCart();
+
   const [products, setProducts] = useState<ProductGet[]>([]);
   const { handleError } = useErrorHandler();
 
@@ -316,6 +321,13 @@ const ProductListScreen = () => {
     setTransferRequestModalOpen(true);
   }, []);
 
+  const handleAddToOrderCart = useCallback(
+    (product: ProductGet) => {
+      orderCart.addItem(product);
+    },
+    [orderCart.addItem]
+  );
+
   const handleAddSelectedToCart = useCallback(() => {
     const selectedProducts = getAllSelectedProducts();
 
@@ -352,6 +364,28 @@ const ProductListScreen = () => {
     clearAllSelections,
     getBehaviorValue,
   ]);
+
+  const handleAddSelectedToOrderCart = useCallback(() => {
+    const selectedProducts = getAllSelectedProducts();
+
+    if (selectedProducts.length === 0) {
+      showErrorToast({
+        title: "Error al agregar los productos",
+        description: `No hay productos seleccionados para agregar al pedido.`,
+      });
+      return;
+    }
+
+    try {
+      orderCart.addMany(selectedProducts);
+      clearAllSelections();
+    } catch (error) {
+      showErrorToast({
+        title: "Error al agregar los productos",
+        description: `Error al procesar productos para el carrito de pedido`,
+      });
+    }
+  }, [getAllSelectedProducts, orderCart.addMany, clearAllSelections]);
 
   const columns = useMemo<ColumnDef<ProductGet>[]>(
     () => [
@@ -449,17 +483,19 @@ const ProductListScreen = () => {
                     <ArrowLeftRight className="mr-2 h-4 w-4" />
                     Solicitar transferencia
                   </DropdownMenuItem>
+                  {isFeatureEnabled("addToOrderCart") && (
+                    <DropdownMenuItem
+                      onClick={() => handleAddToOrderCart(row.original)}
+                    >
+                      <ClipboardList className="mr-2 h-4 w-4" />
+                      Agregar a pedido
+                    </DropdownMenuItem>
+                  )}
                   {/* <DropdownMenuItem
                                     onKeyDown={(e) => e.stopPropagation()}
                                     onClick={() => handleViewDetails(row.original.id)}>
                                     <TrendingUp className="mr-2 h-4 w-4" />
                                     Ver estadisticas
-                                </DropdownMenuItem> */}
-                  {/* <DropdownMenuItem
-                                    onKeyDown={(e) => e.stopPropagation()}
-                                    onClick={() => handleAddItemCart(row.original)}>
-                                    <ShoppingCart className="mr-2 h-4 w-4" />
-                                    Agregar al carrito
                                 </DropdownMenuItem> */}
 
                   {/* <DropdownMenuItem
@@ -686,6 +722,7 @@ const ProductListScreen = () => {
       handleViewImage,
       handleUpdateProduct,
       handleRequestTransfer,
+      handleAddToOrderCart,
     ]
   );
 
@@ -1072,6 +1109,12 @@ const ProductListScreen = () => {
                   <ColumnVisibilityDropdown table={table} />
                 )}
 
+                {/* Carrito de Pedido (badge + panel) */}
+                {(isFeatureEnabled("addToOrderCart") ||
+                  isFeatureEnabled("bulkAddToOrderCart")) && (
+                  <OrderCartBadgeButton />
+                )}
+
                 {/* Acciones de Selección Múltiple */}
                 {isFeatureEnabled("bulkAddToCart") &&
                   getSelectedCount() > 0 && (
@@ -1093,6 +1136,25 @@ const ProductListScreen = () => {
                         </Badge>
                       </Button>
                     </>
+                  )}
+
+                {/* Acción de Selección Múltiple — Carrito de Pedido */}
+                {isFeatureEnabled("bulkAddToOrderCart") &&
+                  getSelectedCount() > 0 && (
+                    <Button
+                      variant="outline"
+                      className="relative"
+                      onClick={handleAddSelectedToOrderCart}
+                    >
+                      <ClipboardList className="size-4" />
+                      Agregar a pedido
+                      <Badge
+                        variant="destructive"
+                        className="absolute -top-2 -right-2 h-5 w-5 flex items-center justify-center p-0 text-[10px]"
+                      >
+                        {getSelectedCount()}
+                      </Badge>
+                    </Button>
                   )}
 
                 {/* Ayuda de Atajos de Teclado */}

--- a/src/view-configs/viewConfigTypes.ts
+++ b/src/view-configs/viewConfigTypes.ts
@@ -28,6 +28,12 @@ export interface ViewFeaturesConfig {
   // Features personalizadas (extensible)
   permissions?: ViewFeatureConfig;
   saveButton?: ViewFeatureConfig;
+
+  // Carrito de pedido (order-cart)
+  addToOrderCart?: ViewFeatureConfig;
+  bulkAddToOrderCart?: ViewFeatureConfig;
+  seedFromOrderCart?: ViewFeatureConfig;
+
   [key: string]: ViewFeatureConfig | undefined;
 }
 


### PR DESCRIPTION
## Qué resuelve

Hoy, cuando alguien detecta un faltante mientras navega el listado de productos, tiene que salirse del listado, abrir la creación de pedido y volver a buscar el producto uno por uno. Esa fricción hace que terminen anotando en papel — o directamente olvidándose.

Con este cambio, marcar un faltante es **un gesto** desde el menú de acciones del listado, y la lista acumulada siembra el pedido de un click.

**Todo el cambio es de frontend.** No toca `OrderCreateSchema`, no agrega endpoints, no requiere migración.

## Cómo funciona

**En el listado de productos** (`ProductListScreen`)
- Nuevo ítem "Agregar a pedido" en el menú de 3 puntitos, siguiendo el patrón de "Solicitar transferencia"
- Acción masiva sobre la multi-selección ya existente
- Badge con el conteo en el toolbar, que abre el panel de gestión (ver, editar cantidad, quitar, vaciar)
- Se reemplazó un bloque comentado muerto (`handleAddItemCart`) que quedaba de un intento previo

**En la creación de pedido** (`orderCreateScreen`)
- Botón "Traer del carrito (N)" que abre el panel
- Dentro del panel, un botón trae **todo** de un click
- La selección producto por producto queda detrás del flag `seedFromOrderCartSelective`, **apagado** — en la práctica se trae el carrito completo, y obligar a tildar ítem por ítem duplicaba el trabajo. Se conserva para un posible uso futuro.

## Decisiones de diseño

**Store nuevo, no un modo del carrito de ventas.** El carrito de ventas (`src/modules/shoppingCart/`) tiene toda su validación construida sobre *tener* stock (`NO_STOCK`, `EXCEEDS_STOCK`), y un pedido es lo inverso: se pide lo que falta. Además es un único carrito por usuario, así que reutilizarlo pisaría una venta en curso. **No se modificó ni un archivo de `shoppingCart/`.**

**Llaveado por id, no por nombre.** El carrito de ventas se llavea `cart-storage-{user.name}-{branchId}`, lo que hace que usuarios homónimos compartan carrito y que un nombre vacío caiga a un bucket `"guest"` compartido. Acá se llavea por `authSDK.getCurrentUser()?.id` + sucursal, y el scope se resuelve **dentro del hook** en vez de recibirse por argumentos — así ningún call site puede pasarlo mal.

**Sin usuario o sin sucursal → carrito nulo.** No persiste, acciones no-op, `isReady: false`, entry points ocultos. Esto cubre la ventana de hidratación async del SDK de auth (usa indexedDB), donde `getCurrentUser()` devuelve `null` en el primer render aunque haya sesión. El hook se suscribe a `onAuthStateChanged` para no quedarse pegado.

**Cero lógica de precios.** El carrito guarda un snapshot de `ProductGet` + cantidad, que es exactamente lo que consume `addMultipleProducts`. La derivación de costo/precio sigue viviendo solo en `useOrderDetails`.

## Dos defectos preexistentes que se compensan (sin corregirlos)

`useOrderDetails.addMultipleProducts` tiene dos problemas que **no se tocan en este PR** (están fuera de alcance), pero que el traspaso tiene que esquivar:

1. En la rama de ítem nuevo hace `cantidad: product.quantity` **sin** `?? 1` (la rama de merge sí lo tiene). Pasar un `ProductGet` crudo dejaría `cantidad: undefined` en el detalle. → El handoff mapea explícito `{ ...item.product, quantity: item.cantidad }`.
2. `addedProductIds.push()` está **solo dentro del `else`**: un producto que ya estaba en el pedido se mergea y su id nunca se retorna. Vaciar el carrito por ese retorno dejaría colgado un ítem que sí entró. → Se vacía por el subconjunto seleccionado.

Ambas compensaciones están comentadas en el código citando la línea del defecto, para que no se "simplifiquen" después.

## Restricción a respetar

Cada `WebviewWindow` de Tauri tiene su propio `localStorage` y el carrito **no** tiene sync `emit`/`listen`. Agregar y consumir se quedan en la ventana principal (TabContainer). **No cablear a `OrderSelectorWindow` ni a `useProductSelectorWindow`** — el carrito leería vacío y escribiría en otro bucket, en silencio.

## Rollback

Apagar `addToOrderCart` / `bulkAddToOrderCart` / `seedFromOrderCart` en los configs y los entry points desaparecen. Es aditivo y aislado: sin migración, sin backend, sin impacto en el carrito de ventas. Las claves residuales de `localStorage` quedan inertes.

## Testing

- `npx tsc --noEmit -p tsconfig.app.json` → **0 errores** en los archivos nuevos y modificados. El repo arrastra errores de tipos preexistentes en otros archivos, ajenos a este cambio.
- Verificado en la app: el flujo de abrir el panel y traer al pedido funciona. Se encontró y corrigió un bug en el camino — los botones del carrito se montan dentro del `<form>` de `orderCreateScreen` y, como el `Button` base no fuerza `type`, heredaban `type="submit"` y disparaban la validación del formulario en vez de abrir el panel.

### Pendiente de verificar

- Persistencia entre reinicios de la app
- Aislamiento entre usuarios distintos y entre sucursales del mismo usuario
- Que el carrito de ventas quede demostrablemente intacto
- Comportamiento con los feature flags apagados
